### PR TITLE
feat(client): 为 BotClient 增加异步事件流接口

### DIFF
--- a/ncatbot/core/__init__.py
+++ b/ncatbot/core/__init__.py
@@ -4,7 +4,14 @@ NcatBot 核心模块
 提供 Bot 客户端、事件系统和 API 接口。
 """
 
-from .client import BotClient, EventBus, NcatBotEvent, EventType, NcatBotEventFactory
+from .client import (
+    BotClient,
+    ClientEventStream,
+    EventBus,
+    NcatBotEvent,
+    EventType,
+    NcatBotEventFactory,
+)
 from .helper import ForwardConstructor  # noqa: F401
 from .api import BotAPI, IBotAPI
 from .event import GroupMessageEvent as GroupMessage
@@ -26,6 +33,7 @@ __all__ = [
     "BotClient",
     "EventBus",
     "NcatBotEvent",
+    "ClientEventStream",
     "ForwardConstructor",
     "EventType",
     "MessageSentEvent",

--- a/ncatbot/core/client/__init__.py
+++ b/ncatbot/core/client/__init__.py
@@ -7,6 +7,7 @@ Client 模块
 from .ncatbot_event import NcatBotEvent, NcatBotEventFactory
 from .event_bus import EventBus, HandlerTimeoutError
 from .dispatcher import EventDispatcher, parse_event_type
+from .event_stream import ClientEventStream, normalize_event_stream_type
 from .registry import EventRegistry
 from .lifecycle import LifecycleManager, StartArgs, LEGAL_ARGS
 from .client import BotClient
@@ -20,6 +21,7 @@ __all__ = [
     "EventDispatcher",
     "EventRegistry",
     "LifecycleManager",
+    "ClientEventStream",
     # 事件
     "NcatBotEvent",
     "NcatBotEventFactory",
@@ -30,4 +32,5 @@ __all__ = [
     # 事件类型
     "EventType",
     "parse_event_type",
+    "normalize_event_stream_type",
 ]

--- a/ncatbot/core/client/client.py
+++ b/ncatbot/core/client/client.py
@@ -4,11 +4,12 @@ Bot 客户端
 组合各模块，提供统一的 Bot 客户端接口。
 """
 
-from typing import List, Optional, Type, TypeVar, TYPE_CHECKING
+from typing import AsyncIterator, List, Optional, Type, TypeVar, TYPE_CHECKING, Union
 
 from ncatbot.utils import get_log
 from ncatbot.utils.error import NcatBotError
 from ncatbot.core.api.interface import IBotAPI
+from ncatbot.core.event.enums import EventType
 from ncatbot.core.service import ServiceManager
 from ncatbot.core.service.builtin import (
     PluginConfigService,
@@ -22,11 +23,13 @@ from ncatbot.adapter.napcat import NapCatAdapter
 
 from .event_bus import EventBus
 from .dispatcher import EventDispatcher
+from .event_stream import ClientEventStream
 from .registry import EventRegistry
 from .lifecycle import LifecycleManager
 
 if TYPE_CHECKING:
     from ncatbot.plugin_system import BasePlugin
+    from .ncatbot_event import NcatBotEvent
 
 T = TypeVar("T")
 LOG = get_log("Client")
@@ -158,6 +161,40 @@ class BotClient(EventRegistry, LifecycleManager):
         self.on_startup()(lambda e: LOG.info(f"Bot {e.self_id} 启动成功"))
 
     # ==================== 工具方法 ====================
+
+    def events(
+        self,
+        event_type: Optional[Union[str, EventType]] = None,
+        *,
+        priority: int = 0,
+        timeout: Optional[float] = None,
+    ) -> ClientEventStream:
+        """创建一个新的异步事件流订阅。
+
+        每次调用都会创建独立的 EventBus 订阅，因此多个协程可以分别
+        获取完整事件流而不会互相竞争消费。若需要在提前退出循环时
+        确定性释放订阅，推荐配合 `async with` 或显式调用 `aclose()`。
+
+        Args:
+            event_type: 订阅的事件类型。默认订阅全部 `ncatbot.*` 事件。
+                传入 EventType 时会自动映射到 `ncatbot.{value}`。
+                传入字符串时会直接透传给 EventBus，因此同样支持 `re:`
+                正则语法。
+            priority: 订阅优先级。
+            timeout: 单个事件处理回调的超时时间。
+        """
+
+        return ClientEventStream(
+            self.event_bus,
+            event_type,
+            priority=priority,
+            timeout=timeout,
+        )
+
+    def __aiter__(self) -> AsyncIterator["NcatBotEvent"]:
+        """允许直接 `async for event in bot` 遍历全量事件流。"""
+
+        return self.events()
 
     def get_registered_plugins(self) -> List["BasePlugin"]:
         """获取已注册的插件列表"""

--- a/ncatbot/core/client/event_stream.py
+++ b/ncatbot/core/client/event_stream.py
@@ -1,0 +1,207 @@
+"""
+BotClient 事件流。
+
+为 BotClient 提供按需订阅的异步事件流接口。
+"""
+
+from __future__ import annotations
+
+import asyncio
+import concurrent.futures
+from typing import TYPE_CHECKING, Callable, Optional, TypeVar, Union
+
+from ncatbot.utils import get_log
+
+from ..event.enums import EventType
+from .ncatbot_event import NcatBotEvent
+
+if TYPE_CHECKING:
+    from .event_bus import EventBus
+
+T = TypeVar("T")
+LOG = get_log("ClientEventStream")
+_STOP = object()
+_ALL_EVENTS = r"re:ncatbot\..*"
+
+
+def normalize_event_stream_type(event_type: Optional[Union[str, EventType]]) -> str:
+    """规范化事件流订阅类型。
+
+    EventType 枚举会被映射到 EventBus 中实际发布的
+    `ncatbot.{event_type.value}` 事件名；字符串则保持原样，
+    因此同样支持 `re:` 正则订阅和前缀订阅。
+    """
+
+    if event_type is None:
+        return _ALL_EVENTS
+
+    if isinstance(event_type, EventType):
+        return f"ncatbot.{event_type.value}"
+
+    return event_type
+
+
+class ClientEventStream:
+    """BotClient 的一次性异步事件流订阅。
+
+    每个实例都拥有独立的 EventBus 订阅。若需要确定性释放订阅，
+    请优先使用 `async with` 或显式调用 :meth:`aclose`。
+    """
+
+    def __init__(
+        self,
+        event_bus: "EventBus",
+        event_type: Optional[Union[str, EventType]] = None,
+        *,
+        priority: int = 0,
+        timeout: Optional[float] = None,
+    ) -> None:
+        self._event_bus = event_bus
+        self._event_type = normalize_event_stream_type(event_type)
+        self._priority = priority
+        self._timeout = timeout
+
+        self._queue: Optional[asyncio.Queue[object]] = None
+        self._consumer_loop: Optional[asyncio.AbstractEventLoop] = None
+        self._handler_id = None
+        self._opened = False
+        self._closed = False
+
+    @property
+    def closed(self) -> bool:
+        """当前订阅是否已关闭。"""
+
+        return self._closed
+
+    @property
+    def event_type(self) -> str:
+        """当前订阅的 EventBus 事件名。"""
+
+        return self._event_type
+
+    async def __aenter__(self) -> "ClientEventStream":
+        await self._open()
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        await self.aclose()
+
+    def __aiter__(self) -> "ClientEventStream":
+        return self
+
+    async def __anext__(self) -> NcatBotEvent:
+        if self._closed and (self._queue is None or self._queue.empty()):
+            raise StopAsyncIteration
+
+        await self._open()
+        assert self._queue is not None
+
+        item = await self._queue.get()
+        if item is _STOP:
+            raise StopAsyncIteration
+
+        return item
+
+    def __del__(self) -> None:
+        try:
+            self._close_sync()
+        except Exception:  # pragma: no cover - 析构阶段只做兜底清理
+            pass
+
+    async def aclose(self) -> None:
+        """关闭当前订阅并停止后续迭代。"""
+
+        if self._closed:
+            return
+
+        self._closed = True
+
+        if self._handler_id is not None:
+            handler_id = self._handler_id
+            self._handler_id = None
+            await self._run_on_event_bus_loop(
+                lambda: self._event_bus.unsubscribe(handler_id)
+            )
+
+        self._wake_consumer()
+
+    async def _open(self) -> None:
+        if self._opened:
+            return
+
+        if self._closed:
+            raise RuntimeError("ClientEventStream 已关闭，请重新调用 bot.events()")
+
+        self._consumer_loop = asyncio.get_running_loop()
+        self._queue = asyncio.Queue()
+
+        async def _handler(event: NcatBotEvent) -> None:
+            if self._closed or self._consumer_loop is None or self._queue is None:
+                return
+
+            # 使用 loop-safe handoff，这样在后台线程运行 Bot 时也能把事件
+            # 安全转交给消费方所在的事件循环。
+            self._consumer_loop.call_soon_threadsafe(self._queue.put_nowait, event)
+
+        self._handler_id = await self._run_on_event_bus_loop(
+            lambda: self._event_bus.subscribe(
+                self._event_type,
+                _handler,
+                priority=self._priority,
+                timeout=self._timeout,
+            )
+        )
+        self._opened = True
+
+    def _close_sync(self) -> None:
+        if self._closed:
+            return
+
+        self._closed = True
+
+        if self._handler_id is not None:
+            handler_id = self._handler_id
+            self._handler_id = None
+
+            event_loop = self._event_bus._loop
+            if event_loop is not None and not event_loop.is_closed():
+                event_loop.call_soon_threadsafe(self._event_bus.unsubscribe, handler_id)
+            else:
+                self._event_bus.unsubscribe(handler_id)
+
+        self._wake_consumer()
+
+    def _wake_consumer(self) -> None:
+        if self._consumer_loop is None or self._queue is None:
+            return
+        if self._consumer_loop.is_closed():
+            return
+
+        self._consumer_loop.call_soon_threadsafe(self._queue.put_nowait, _STOP)
+
+    async def _run_on_event_bus_loop(self, func: Callable[[], T]) -> T:
+        """在 EventBus 绑定的事件循环上执行同步操作。"""
+
+        event_loop = self._event_bus._loop
+        current_loop = asyncio.get_running_loop()
+
+        if (
+            event_loop is None
+            or event_loop == current_loop
+            or event_loop.is_closed()
+        ):
+            return func()
+
+        result: concurrent.futures.Future[T] = concurrent.futures.Future()
+
+        def _runner() -> None:
+            try:
+                result.set_result(func())
+            except Exception as exc:  # pragma: no cover - 防御性分支
+                result.set_exception(exc)
+
+        event_loop.call_soon_threadsafe(_runner)
+        return await asyncio.wrap_future(result)
+
+
+__all__ = ["ClientEventStream", "normalize_event_stream_type"]

--- a/test/core/client/test_event_stream.py
+++ b/test/core/client/test_event_stream.py
@@ -1,0 +1,145 @@
+"""
+ClientEventStream / BotClient.events 测试
+"""
+
+import asyncio
+
+import pytest
+
+from ncatbot.core import BotClient, EventType, NcatBotEvent
+
+
+@pytest.fixture(autouse=True)
+def reset_bot_client_singleton():
+    """每个测试前重置 BotClient 单例状态。"""
+
+    BotClient._initialized = False
+    yield
+    BotClient._initialized = False
+
+
+class TestClientEventStream:
+    """测试 BotClient 事件流接口。"""
+
+    @pytest.mark.asyncio
+    async def test_events_yield_all_ncatbot_events(self, mock_adapter):
+        """默认事件流应接收全部 ncatbot.* 事件。"""
+
+        client = BotClient(adapter=mock_adapter)
+        stream = client.events()
+        iterator = stream.__aiter__()
+
+        payload = {"raw_message": "hello"}
+        publish_task = asyncio.create_task(
+            client.event_bus.publish(NcatBotEvent("ncatbot.message_event", payload))
+        )
+
+        event = await asyncio.wait_for(anext(iterator), timeout=1.0)
+        await publish_task
+        await iterator.aclose()
+
+        assert event.type == "ncatbot.message_event"
+        assert event.data == payload
+
+    @pytest.mark.asyncio
+    async def test_events_filter_by_event_type_enum(self, mock_adapter):
+        """EventType 应映射到带 ncatbot 前缀的真实事件名。"""
+
+        client = BotClient(adapter=mock_adapter)
+
+        async with client.events(EventType.MESSAGE) as stream:
+            iterator = stream.__aiter__()
+
+            await client.event_bus.publish(
+                NcatBotEvent("ncatbot.notice_event", {"notice": True})
+            )
+            await client.event_bus.publish(
+                NcatBotEvent("ncatbot.message_event", {"raw_message": "ping"})
+            )
+
+            event = await asyncio.wait_for(anext(iterator), timeout=1.0)
+
+        assert event.type == "ncatbot.message_event"
+        assert event.data["raw_message"] == "ping"
+
+    @pytest.mark.asyncio
+    async def test_each_events_call_creates_independent_subscription(self, mock_adapter):
+        """不同事件流订阅应各自收到完整事件。"""
+
+        client = BotClient(adapter=mock_adapter)
+
+        async with client.events(EventType.MESSAGE) as stream1:
+            async with client.events(EventType.MESSAGE) as stream2:
+                iterator1 = stream1.__aiter__()
+                iterator2 = stream2.__aiter__()
+
+                await client.event_bus.publish(
+                    NcatBotEvent("ncatbot.message_event", {"raw_message": "fanout"})
+                )
+
+                event1, event2 = await asyncio.wait_for(
+                    asyncio.gather(anext(iterator1), anext(iterator2)),
+                    timeout=1.0,
+                )
+
+        assert event1.data["raw_message"] == "fanout"
+        assert event2.data["raw_message"] == "fanout"
+
+    @pytest.mark.asyncio
+    async def test_events_aclose_unsubscribes_handler(self, mock_adapter):
+        """显式关闭事件流后应从 EventBus 退订。"""
+
+        client = BotClient(adapter=mock_adapter)
+        stream = client.events(EventType.MESSAGE)
+
+        assert "ncatbot.message_event" not in client.event_bus._exact
+
+        await stream.__aenter__()
+        assert len(client.event_bus._exact["ncatbot.message_event"]) == 1
+
+        await stream.aclose()
+
+        assert "ncatbot.message_event" not in client.event_bus._exact
+        assert stream.closed is True
+
+    @pytest.mark.asyncio
+    async def test_bot_is_async_iterable(self, mock_adapter):
+        """BotClient 本身应支持直接 async for 取事件。"""
+
+        client = BotClient(adapter=mock_adapter)
+        iterator = client.__aiter__()
+
+        publish_task = asyncio.create_task(
+            client.event_bus.publish(NcatBotEvent("ncatbot.meta_event", {"ok": True}))
+        )
+
+        event = await asyncio.wait_for(anext(iterator), timeout=1.0)
+        await publish_task
+        await iterator.aclose()
+
+        assert event.type == "ncatbot.meta_event"
+        assert event.data == {"ok": True}
+
+    @pytest.mark.asyncio
+    async def test_async_with_break_releases_subscription(self, mock_adapter):
+        """在 async with 中 break 退出后，应确定性地释放订阅。"""
+
+        client = BotClient(adapter=mock_adapter)
+
+        async def producer():
+            await asyncio.sleep(0)
+            await client.event_bus.publish(
+                NcatBotEvent("ncatbot.message_event", {"raw_message": "once"})
+            )
+
+        async with client.events(EventType.MESSAGE) as stream:
+            task = asyncio.create_task(producer())
+
+            async for event in stream:
+                assert event.data["raw_message"] == "once"
+                break
+
+        await task
+        await asyncio.sleep(0)
+
+        assert "ncatbot.message_event" not in client.event_bus._exact


### PR DESCRIPTION
## 变更背景

当前 `BotClient` 的事件消费方式主要是装饰器回调，外部如果希望以“拉流”的方式消费事件，例如：

- 在上层应用中 `async for` 持续读取事件
- 为不同协程分别建立独立事件流
- 在不改动 adapter / websocket 层的前提下，从 `client` 侧统一拿到标准化事件

就缺少一个合适的入口。

这次改动为 `BotClient` 增加了按需创建的异步事件流接口，使外部可以直接通过异步迭代获取 `NcatBotEvent`。

## 主要改动

### 1. 新增 `ClientEventStream`

新增 `ncatbot/core/client/event_stream.py`：

- 每个 `ClientEventStream` 实例都会创建一条独立的 `EventBus` 订阅
- 内部使用 `asyncio.Queue` 作为事件桥接缓冲区
- 支持 `EventType` 自动映射到真实事件名，例如 `EventType.MESSAGE -> ncatbot.message_event`
- 也支持直接传字符串，因此兼容精确事件名、前缀事件名和 `re:` 正则订阅
- 在后台线程模式下，使用 loop-safe handoff 将事件安全转交给消费者所在的事件循环

### 2. 为 `BotClient` 增加事件流入口

在 `BotClient` 上新增：

- `bot.events(...)`：创建一个新的异步事件流订阅
- `bot.__aiter__()`：允许直接 `async for event in bot` 遍历默认全量事件流

设计语义是：

- 每次 `bot.events()` 都会新建一个订阅
- 不同协程各自拿自己的流对象时，可以分别收到完整事件流
- 不会因为共享一个队列而互相竞争消费

### 3. 补充导出

已在以下位置导出新接口：

- `ncatbot.core.client`
- `ncatbot.core`

这样用户可以直接从公共入口导入 `ClientEventStream` 或继续只用 `BotClient`。

### 4. 新增测试

新增 `test/core/client/test_event_stream.py`，覆盖：

- 默认全量事件流
- `EventType` 过滤
- 多次 `events()` 调用创建独立订阅
- `aclose()` 后退订
- `BotClient` 直接异步迭代
- `async with` + `break` 后确定性释放订阅

## 设计说明

这次实现刻意没有去改 websocket / adapter 监听链路，而是把能力加在 `EventBus` 之上，原因是：

- `dispatcher.dispatch()` 已经把平台事件标准化为 `NcatBotEvent`
- `EventBus` 是框架内部统一的事件汇聚点
- 从这里暴露事件流，对上层调用者来说更稳定，也不会耦合平台实现细节

另外，这里也明确了一个使用约束：

- 如果只是临时消费几个事件然后提前退出，推荐使用 `async with bot.events(...) as stream`
- 或者在 `finally` 里手动 `await stream.aclose()`

这样可以保证订阅被确定性释放。

之所以在 PR 里明确说明这一点，是因为 Python 本身对 bare `async for ... break` 的自定义异步迭代器清理并不提供完全可靠的“立即退订”语义，所以这里把“确定性关闭”放在了 `async with` / `aclose()` 这一层。

## 用户侧使用方式

### 方式一：按事件类型消费

```python
from ncatbot.core import BotClient, EventType

bot = BotClient()
api = await bot.run_backend_async(...)

async with bot.events(EventType.MESSAGE) as stream:
    async for event in stream:
        print(event.type)
        print(event.data.raw_message)
```

### 方式二：直接遍历 `BotClient`

```python
from ncatbot.core import BotClient

bot = BotClient()
api = await bot.run_backend_async(...)

async for event in bot:
    print(event.type, event.data)
```

上面等价于默认订阅全部 `ncatbot.*` 事件。

### 方式三：提前退出时显式关闭

```python
stream = bot.events()
try:
    async for event in stream:
        if should_stop(event):
            break
finally:
    await stream.aclose()
```

### 方式四：使用字符串或正则订阅

```python
async with bot.events("ncatbot.message_event") as stream:
    async for event in stream:
        ...

async with bot.events(r"re:ncatbot\\.(message|notice)_event") as stream:
    async for event in stream:
        ...
```

## 验证结果

已执行：

```bash
uv run pytest -o addopts='' test/core/client/test_event_stream.py test/core/client/test_client.py test/core/client/test_dispatcher.py test/core/client/test_registry_core.py test/core/client/test_registry_handlers.py test/core/client/test_registry_decorators.py test/core/client/test_ncatbot_event.py
```

结果：`104 passed`

## 影响范围

本次改动主要影响 `client` 层公开接口：

- 新增异步事件流能力
- 不改变现有装饰器注册方式
- 不改变 adapter / dispatcher 的既有事件获取链路

因此对现有基于装饰器的用法是增量增强，不是破坏性修改。
