### PR TITLE
重构 client event_bus 为异步事件流模型

### DIFF
--- a/ncatbot/adapter/base.py
+++ b/ncatbot/adapter/base.py
@@ -145,7 +145,7 @@ class BaseAdapter(ABC):
         """设置事件回调
 
         由 BotClient 在启动阶段调用，将转换后的标准 Event
-        传递给 Core 层的 EventDispatcher。
+        传递给 Core 层的 EventBus 入口。
 
         Args:
             callback: 接收标准 Event 的异步回调函数

--- a/ncatbot/core/client/client.py
+++ b/ncatbot/core/client/client.py
@@ -4,7 +4,7 @@ Bot 客户端
 组合各模块，提供统一的 Bot 客户端接口。
 """
 
-from typing import List, Optional, Type, TypeVar, TYPE_CHECKING
+from typing import AsyncGenerator, Callable, List, Optional, Type, TypeVar, TYPE_CHECKING
 
 from ncatbot.utils import get_log
 from ncatbot.utils.error import NcatBotError
@@ -27,6 +27,7 @@ from .lifecycle import LifecycleManager
 
 if TYPE_CHECKING:
     from ncatbot.plugin_system import BasePlugin
+    from ncatbot.core.event import BaseEvent
 
 T = TypeVar("T")
 LOG = get_log("Client")
@@ -46,12 +47,12 @@ class BotClient(EventRegistry, LifecycleManager):
     │       │             │             │             │       │
     │       └─────────────┴─────────────┴─────────────┘       │
     │                         ↓                               │
-    │                   EventDispatcher                       │
-    │                    (解析 & 分发)                         │
+    │                    EventBus Callback                    │
+    │                    (Adapter 事件入口)                    │
     └─────────────────────────────────────────────────────────┘
 
     事件流：
-    MessageRouter → Dispatcher → EventBus → Handlers/Plugins
+    Adapter → EventBus → Handlers/Plugins
 
     继承：
     - EventRegistry: 提供事件注册和装饰器接口
@@ -83,17 +84,26 @@ class BotClient(EventRegistry, LifecycleManager):
         # 2. 注册引擎（直接订阅 EventBus）
         self.registry_engine = RegistryEngine()
 
-        self.event_bus.subscribe(
-            "re:ncatbot\\.group_message_event|ncatbot\\.private_message_event"
-            "|ncatbot\\.message_sent_event",
-            self._on_message_for_registry,
-            priority=0,
-        )
-        self.event_bus.subscribe(
-            "re:ncatbot\\.notice_event|ncatbot\\.request_event|ncatbot\\.meta_event",
-            self._on_legacy_for_registry,
-            priority=0,
-        )
+        for event_type in (
+            "ncatbot.group_message_event",
+            "ncatbot.private_message_event",
+            "ncatbot.message_sent_event",
+        ):
+            self.event_bus.subscribe(
+                event_type,
+                self._on_message_for_registry,
+                priority=0,
+            )
+        for event_type in (
+            "ncatbot.notice_event",
+            "ncatbot.request_event",
+            "ncatbot.meta_event",
+        ):
+            self.event_bus.subscribe(
+                event_type,
+                self._on_legacy_for_registry,
+                priority=0,
+            )
 
         # 3. 服务管理器（注入 EventBus）
         self.services = ServiceManager(event_bus=self.event_bus)
@@ -131,16 +141,14 @@ class BotClient(EventRegistry, LifecycleManager):
 
     async def _setup_api(self) -> None:
         """设置 API（在 adapter.connect() 后调用）"""
-        from .dispatcher import EventDispatcher
-
         # 从适配器获取 IBotAPI
         self.api = self.adapter.get_api()
 
-        # 创建事件分发器
+        # 保留一个薄分发器，便于测试和手动注入 dict 事件
         self.dispatcher = EventDispatcher(self.event_bus, self.api)
 
-        # 将适配器的事件输出连接到分发器
-        self.adapter.set_event_callback(self.dispatcher.dispatch)
+        # adapter 直接将标准事件交给 EventBus
+        self.adapter.set_event_callback(self.event_bus.on_adapter_event)
 
         # 注入 BotClient 引用到 RegistryEngine（过渡期）
         self.registry_engine.set_bot_client(self)
@@ -155,7 +163,24 @@ class BotClient(EventRegistry, LifecycleManager):
 
     def _register_builtin_handlers(self):
         """注册内置处理器"""
-        self.on_startup()(lambda e: LOG.info(f"Bot {e.self_id} 启动成功"))
+        @self.on_startup()
+        async def _log_startup(event) -> None:
+            LOG.info("Bot %s 启动成功", event.self_id)
+
+    def events(self) -> AsyncGenerator["BaseEvent", None]:
+        """按异步事件流消费 adapter 事件。"""
+        return self.event_bus.events()
+
+    def __aiter__(self) -> AsyncGenerator["BaseEvent", None]:
+        return self.events()
+
+    async def wait_event(
+        self,
+        predicate: Callable[["BaseEvent"], bool],
+        timeout: Optional[float] = None,
+    ) -> "BaseEvent":
+        """等待下一条满足条件的 adapter 事件。"""
+        return await self.event_bus.wait_event(predicate, timeout)
 
     # ==================== 工具方法 ====================
 

--- a/ncatbot/core/client/dispatcher.py
+++ b/ncatbot/core/client/dispatcher.py
@@ -1,10 +1,9 @@
 """
 事件分发器
 
-负责接收事件，分发到 EventBus。
-支持两种模式：
-1. 接收原始 dict 数据（传统模式）
-2. 接收已转换的 BaseEvent 对象（新 Adapter 模式）
+保留为一个薄桥接层：
+1. 接收原始 dict 数据时，负责解析为标准事件
+2. 接收 BaseEvent 时，直接转交给 EventBus 的 adapter 回调入口
 """
 
 import traceback
@@ -88,15 +87,7 @@ class EventDispatcher:
             data_or_event: 原始数据 dict 或已转换的 BaseEvent
         """
         if isinstance(data_or_event, BaseEvent):
-            # 新 Adapter 模式：事件已转换
-            event = data_or_event
-            event_type = self._get_event_type_from_event(event)
-            if not event_type:
-                LOG.debug(f"未知事件类型: {event.post_type}")
-                return
-
-            ncatbot_event = NcatBotEvent(f"ncatbot.{event_type.value}", event)
-            await self.event_bus.publish(ncatbot_event)
+            await self.event_bus.on_adapter_event(data_or_event, wait=True)
             return
 
         # 传统模式：从 dict 解析
@@ -108,32 +99,12 @@ class EventDispatcher:
 
         try:
             event = EventParser.parse(data, self.api)
-            ncatbot_event = NcatBotEvent(f"ncatbot.{event_type.value}", event)
-            await self.event_bus.publish(ncatbot_event)
+            await self.event_bus.publish(NcatBotEvent(f"ncatbot.{event_type.value}", event))
 
         except ValueError as e:
             LOG.warning(f"事件解析失败: {e}")
         except Exception as e:
             LOG.error(f"事件处理出错: {e}\n{traceback.format_exc()}")
-
-    @staticmethod
-    def _get_event_type_from_event(event: BaseEvent) -> Optional[EventType]:
-        """从 BaseEvent 对象获取事件类型"""
-        post_type = getattr(event, "post_type", None)
-        if not post_type:
-            return None
-
-        if post_type == PostType.MESSAGE or post_type == "message":
-            return EventType.MESSAGE
-        if post_type == "message_sent":
-            return EventType.MESSAGE_SENT
-        if post_type == PostType.NOTICE or post_type == "notice":
-            return EventType.NOTICE
-        if post_type == PostType.REQUEST or post_type == "request":
-            return EventType.REQUEST
-        if post_type == PostType.META_EVENT or post_type == "meta_event":
-            return EventType.META
-        return None
 
     async def __call__(self, data_or_event: Union[dict, BaseEvent]) -> None:
         """支持作为回调函数使用"""

--- a/ncatbot/core/client/event_bus.py
+++ b/ncatbot/core/client/event_bus.py
@@ -1,28 +1,38 @@
 """
-事件总线
+异步事件总线
 
-统一的事件分发中心，支持精确匹配、前缀匹配和正则匹配。
+负责两类工作：
+1. 接收 adapter 上报的标准 BaseEvent，并转为 NcatBotEvent 分发
+2. 发布/消费框架内部自定义事件
 """
+
+from __future__ import annotations
 
 import asyncio
 import concurrent.futures
-import re
 import uuid
-from functools import lru_cache
-from typing import Any, Callable, Dict, List, Optional, Tuple, TYPE_CHECKING
+from copy import copy
+from dataclasses import dataclass
+from inspect import isawaitable, iscoroutinefunction
+from typing import TYPE_CHECKING, Any, AsyncGenerator, Callable, Dict, List, Optional, Tuple
 
 from ncatbot.utils import get_log
+
+from ..event.enums import EventType, PostType
+from ..event.events import BaseEvent
+from .ncatbot_event import NcatBotEvent
 
 if TYPE_CHECKING:
     from ncatbot.plugin_system import BasePlugin
 
-from .ncatbot_event import NcatBotEvent
-
 LOG = get_log("EventBus")
+_STOP = object()
+
+AdapterEventPredicate = Callable[[BaseEvent], bool]
 
 
 class HandlerTimeoutError(Exception):
-    """处理器超时异常"""
+    """保留旧异常类型，兼容仍引用该名字的代码。"""
 
     def __init__(self, meta_data: dict, handler: str, time: float):
         super().__init__()
@@ -30,45 +40,56 @@ class HandlerTimeoutError(Exception):
         self.handler = handler
         self.time = time
 
-    def __str__(self):
+    def __str__(self) -> str:
         return f"来自 {self.meta_data['name']} 的处理器 {self.handler} 执行超时 {self.time}"
+
+
+@dataclass(slots=True)
+class _QueuedEvent:
+    event: NcatBotEvent
+    completion: asyncio.Future[List[Any]] | None = None
+    adapter_event: BaseEvent | None = None
+
+
+@dataclass(slots=True)
+class _Waiter:
+    token: object
+    predicate: AdapterEventPredicate
+    future: asyncio.Future[BaseEvent]
 
 
 class EventBus:
     """
-    事件总线
+    异步事件总线。
 
-    统一的事件分发中心，支持：
-    - 精确匹配：event_type 完全匹配
-    - 前缀匹配：如 ncatbot.notice.group_increase 也触发 ncatbot.notice
-    - 正则匹配：使用 "re:" 前缀
-    - 优先级控制：数值越大优先级越高
+    设计目标：
+    - adapter 事件通过单一回调入口进入
+    - 所有事件在单个分发协程中顺序处理，避免并发乱序
+    - 为 BotClient 提供 `async for` 与 `wait_event` 能力
     """
 
-    def __init__(self, default_timeout: float = 120) -> None:
-        """
-        初始化事件总线
-
-        Args:
-            default_timeout: 默认处理器超时时间（秒）
-        """
-        self._exact: Dict[str, List[Tuple]] = {}
-        self._regex: List[Tuple] = []
+    def __init__(
+        self,
+        default_timeout: float = 120,
+        stream_queue_size: int = 500,
+    ) -> None:
+        # 复用旧字段名，减少外围代码的侵入式修改
+        self._exact: Dict[str, List[Tuple[None, int, Callable[[NcatBotEvent], Any], uuid.UUID, float]]] = {}
+        self._handler_meta: Dict[uuid.UUID, Dict[str, Any]] = {}
         self.default_timeout = default_timeout
-        self._handler_meta: Dict[uuid.UUID, Dict] = {}
-        # 主事件循环引用（用于跨线程发布）
+
         self._loop: Optional[asyncio.AbstractEventLoop] = None
+        self._incoming: asyncio.Queue[_QueuedEvent | object] = asyncio.Queue()
+        self._dispatch_task: Optional[asyncio.Task[None]] = None
+        self._startup_lock = asyncio.Lock()
+        self._closed = False
+
+        self._stream_queue_size = stream_queue_size
+        self._stream_queues: set[asyncio.Queue[BaseEvent | object]] = set()
+        self._waiters: List[_Waiter] = []
 
     def bind_loop(self, loop: Optional[asyncio.AbstractEventLoop] = None) -> None:
-        """
-        绑定事件循环
-
-        在异步上下文中调用此方法绑定当前事件循环，以支持跨线程发布。
-        如果不传参数，则自动获取当前运行的事件循环。
-
-        Args:
-            loop: 事件循环，None 则自动获取
-        """
+        """绑定主事件循环，供跨线程发布使用。"""
         if loop is None:
             try:
                 loop = asyncio.get_running_loop()
@@ -77,8 +98,6 @@ class EventBus:
                 return
         self._loop = loop
         LOG.debug("EventBus 已绑定事件循环")
-
-    # ==================== 订阅管理 ====================
 
     def subscribe(
         self,
@@ -89,122 +108,124 @@ class EventBus:
         plugin: Optional["BasePlugin"] = None,
     ) -> uuid.UUID:
         """
-        订阅事件处理程序
+        订阅事件处理程序。
 
-        Args:
-            event_type: 事件类型，支持精确匹配或 "re:" 前缀的正则表达式
-            handler: 事件处理函数（支持同步和异步）
-            priority: 处理优先级，数值越大优先级越高
-            timeout: 处理器超时时间（秒），None 则使用默认值
-            plugin: 插件实例，用于记录元数据
-
-        Returns:
-            处理器唯一标识符
+        仅支持精确事件名匹配，处理器必须是异步函数。
         """
+        if event_type.startswith("re:"):
+            raise ValueError("EventBus 不再支持正则事件订阅")
+        if not self._is_async_handler(handler):
+            raise TypeError("EventBus 仅支持异步事件处理器")
+
         hid = uuid.uuid4()
         timeout_val = timeout if timeout is not None else self.default_timeout
 
         if plugin:
             self._handler_meta[hid] = plugin.meta_data
 
-        if event_type.startswith("re:"):
-            pattern = _compile_regex(event_type[3:])
-            self._regex.append((pattern, priority, handler, hid, timeout_val))
-            self._regex.sort(key=lambda t: (-t[1], t[2].__name__))
-        else:
-            bucket = self._exact.setdefault(event_type, [])
-            bucket.append((None, priority, handler, hid, timeout_val))
-            bucket.sort(key=lambda t: (-t[1], t[2].__name__))
-
+        bucket = self._exact.setdefault(event_type, [])
+        bucket.append((None, priority, handler, hid, timeout_val))
+        bucket.sort(key=lambda item: (-item[1], item[2].__name__))
         return hid
 
     def unsubscribe(self, handler_id: uuid.UUID) -> bool:
-        """
-        取消订阅事件处理程序
-
-        Args:
-            handler_id: subscribe() 返回的处理器标识符
-
-        Returns:
-            是否成功移除处理器
-        """
+        """取消订阅事件处理程序。"""
         removed = False
 
-        if handler_id in self._handler_meta:
-            del self._handler_meta[handler_id]
+        self._handler_meta.pop(handler_id, None)
 
-        for typ in list(self._exact.keys()):
-            original_len = len(self._exact[typ])
-            self._exact[typ] = [h for h in self._exact[typ] if h[3] != handler_id]
-            removed |= len(self._exact[typ]) != original_len
-            if not self._exact[typ]:
-                del self._exact[typ]
-
-        original_len = len(self._regex)
-        self._regex = [h for h in self._regex if h[3] != handler_id]
-        removed |= len(self._regex) != original_len
+        for event_type in list(self._exact.keys()):
+            original_len = len(self._exact[event_type])
+            self._exact[event_type] = [
+                item for item in self._exact[event_type] if item[3] != handler_id
+            ]
+            removed |= len(self._exact[event_type]) != original_len
+            if not self._exact[event_type]:
+                del self._exact[event_type]
 
         return removed
 
-    # ==================== 事件发布 ====================
-
     async def publish(self, event: NcatBotEvent) -> List[Any]:
-        """
-        发布事件并执行所有匹配的处理器
+        """发布自定义事件，并等待其处理完成。"""
+        await self._ensure_runtime()
 
-        Args:
-            event: 要发布的事件
+        loop = asyncio.get_running_loop()
+        completion: asyncio.Future[List[Any]] = loop.create_future()
+        await self._incoming.put(_QueuedEvent(event=event, completion=completion))
+        return await completion
 
-        Returns:
-            所有处理器的返回结果列表
-        """
-        LOG.debug(
-            f"发布事件: {event.type} 数据: {str(event.data)[:50]}{'...' if len(str(event.data)) > 50 else ''}"
+    async def on_adapter_event(self, event: BaseEvent, wait: bool = False) -> None:
+        """adapter 事件入口：标准事件进入总线的唯一回调。"""
+        await self._ensure_runtime()
+
+        event_type = self._get_event_type_from_event(event)
+        if event_type is None:
+            LOG.debug("忽略未知事件类型: %s", getattr(event, "post_type", None))
+            return
+
+        completion: asyncio.Future[List[Any]] | None = None
+        if wait:
+            completion = asyncio.get_running_loop().create_future()
+
+        await self._incoming.put(
+            _QueuedEvent(
+                event=NcatBotEvent(f"ncatbot.{event_type.value}", event),
+                completion=completion,
+                adapter_event=event,
+            )
         )
-        handlers = self._collect_handlers(event.type)
 
-        for _, priority, handler, hid, timeout in handlers:
-            if event._propagation_stopped:
-                break
+        if completion is not None:
+            await completion
 
-            try:
-                result = await asyncio.wait_for(
-                    self._run_handler(handler, event), timeout=timeout
-                )
-                event._results.append(result)
-            except asyncio.TimeoutError:
-                LOG.error(f"处理器 {handler.__name__} (ID: {hid}) 超时({timeout}秒)")
-                meta_data = self._handler_meta.get(hid, {"name": "Unknown"})
-                event.add_exception(
-                    HandlerTimeoutError(
-                        meta_data=meta_data, handler=handler.__name__, time=timeout
-                    )
-                )
-            except Exception as e:
-                event.add_exception(e)
+    async def wait_event(
+        self,
+        predicate: AdapterEventPredicate,
+        timeout: Optional[float] = None,
+    ) -> BaseEvent:
+        """等待下一条满足条件的 adapter 事件。"""
+        await self._ensure_runtime()
 
-        return event._results.copy()
+        loop = asyncio.get_running_loop()
+        token = object()
+        future: asyncio.Future[BaseEvent] = loop.create_future()
+        self._waiters.append(_Waiter(token=token, predicate=predicate, future=future))
+
+        try:
+            if timeout is None:
+                return await future
+            return await asyncio.wait_for(future, timeout)
+        finally:
+            self._remove_waiter(token)
+
+    async def events(self) -> AsyncGenerator[BaseEvent, None]:
+        """按事件流方式消费 adapter 事件。"""
+        await self._ensure_runtime()
+
+        queue: asyncio.Queue[BaseEvent | object] = asyncio.Queue(
+            maxsize=self._stream_queue_size
+        )
+        self._stream_queues.add(queue)
+        try:
+            while True:
+                item = await queue.get()
+                if item is _STOP:
+                    break
+                if isinstance(item, BaseEvent):
+                    yield item
+        finally:
+            self._stream_queues.discard(queue)
+
+    def __aiter__(self) -> AsyncGenerator[BaseEvent, None]:
+        return self.events()
 
     def publish_threadsafe(
         self, event: NcatBotEvent
-    ) -> Optional[concurrent.futures.Future]:
-        """
-        线程安全的事件发布（非阻塞）
-
-        从非异步线程中安全地发布事件到主事件循环。
-        此方法立即返回一个 Future，不会阻塞调用线程。
-
-        Args:
-            event: 要发布的事件
-
-        Returns:
-            Future 对象，可用于获取结果或检查状态；
-            如果事件循环不可用则返回 None
-        """
+    ) -> Optional[concurrent.futures.Future[List[Any]]]:
+        """从非事件循环线程安全地发布自定义事件。"""
         if self._loop is None or self._loop.is_closed():
             LOG.warning("事件循环不可用，无法发布事件")
             return None
-
         return asyncio.run_coroutine_threadsafe(self.publish(event), self._loop)
 
     def publish_threadsafe_wait(
@@ -212,18 +233,7 @@ class EventBus:
         event: NcatBotEvent,
         timeout: Optional[float] = 5.0,
     ) -> Optional[List[Any]]:
-        """
-        线程安全的事件发布（阻塞等待结果）
-
-        从非异步线程中安全地发布事件，并阻塞等待所有处理器执行完成。
-
-        Args:
-            event: 要发布的事件
-            timeout: 等待超时时间（秒），None 表示无限等待
-
-        Returns:
-            处理器返回结果列表；如果超时或事件循环不可用则返回 None
-        """
+        """从非事件循环线程发布自定义事件并阻塞等待结果。"""
         future = self.publish_threadsafe(event)
         if future is None:
             return None
@@ -231,75 +241,191 @@ class EventBus:
         try:
             return future.result(timeout=timeout)
         except concurrent.futures.TimeoutError:
-            LOG.error(f"事件发布超时: {event.type}")
+            LOG.error("事件发布超时: %s", event.type)
             return None
-        except Exception as e:
-            LOG.error(f"事件发布失败: {e}")
+        except Exception as exc:
+            LOG.error("事件发布失败: %s", exc)
             return None
 
-    async def _run_handler(self, handler: Callable, event: NcatBotEvent) -> Any:
-        """
-        执行处理器
+    async def close(self) -> None:
+        """异步关闭事件总线。"""
+        if self._closed:
+            return
 
-        对于异步处理器：直接 await
-        对于同步处理器：使用 asyncio.to_thread() 避免阻塞
-        """
+        self._closed = True
+
+        if self._dispatch_task and not self._dispatch_task.done():
+            await self._incoming.put(_STOP)
+            try:
+                await self._dispatch_task
+            except asyncio.CancelledError:
+                pass
+        else:
+            self._finalize_shutdown()
+
+    def shutdown(self) -> None:
+        """同步关闭，仅适用于尚未启动分发协程的场景。"""
+        self._closed = True
+        if self._dispatch_task and not self._dispatch_task.done():
+            self._dispatch_task.cancel()
+            return
+        self._finalize_shutdown()
+
+    async def _ensure_runtime(self) -> None:
+        if self._closed:
+            raise RuntimeError("EventBus 已关闭")
+
+        loop = asyncio.get_running_loop()
+        if self._loop is None:
+            self._loop = loop
+        elif self._loop is not loop:
+            raise RuntimeError("EventBus 不能跨多个事件循环复用")
+
+        if self._dispatch_task and not self._dispatch_task.done():
+            return
+
+        async with self._startup_lock:
+            if self._dispatch_task and not self._dispatch_task.done():
+                return
+            self._dispatch_task = asyncio.create_task(self._dispatch_loop())
+
+    async def _dispatch_loop(self) -> None:
         try:
-            if asyncio.iscoroutinefunction(handler):
-                return await handler(event)
-            else:
-                return await asyncio.to_thread(handler, event)
-        except Exception as e:
-            LOG.exception(f"执行处理程序 {handler.__name__} 时发生错误: {e}")
-            raise e
+            while True:
+                queued = await self._incoming.get()
+                if queued is _STOP:
+                    break
 
-    def _collect_handlers(self, event_type: str) -> List[Tuple]:
-        """
-        收集匹配的事件处理程序
+                assert isinstance(queued, _QueuedEvent)
 
-        Args:
-            event_type: 事件类型
+                if queued.adapter_event is not None:
+                    self._broadcast_adapter_event(queued.adapter_event)
+                    self._resolve_waiters(queued.adapter_event)
 
-        Returns:
-            匹配的处理器列表（已按优先级排序）
-        """
-        # 精确匹配
-        exact_handlers = self._exact.get(event_type, [])[:]
+                results = await self._dispatch_handlers(queued.event)
+                if queued.completion is not None and not queued.completion.done():
+                    queued.completion.set_result(results)
+        except asyncio.CancelledError:
+            raise
+        finally:
+            self._finalize_shutdown()
 
-        # 前缀匹配（如 ncatbot.notice.group_increase 也触发 ncatbot.notice）
-        prefix_handlers = []
-        parts = event_type.split(".")
-        for i in range(len(parts) - 1, 0, -1):
-            prefix = ".".join(parts[:i])
-            if prefix in self._exact:
-                prefix_handlers.extend(self._exact[prefix])
+    async def _dispatch_handlers(self, event: NcatBotEvent) -> List[Any]:
+        LOG.debug(
+            "发布事件: %s 数据: %s",
+            event.type,
+            f"{str(event.data)[:50]}..." if len(str(event.data)) > 50 else str(event.data),
+        )
+        handlers = self._collect_handlers(event.type)
 
-        # 正则匹配
-        regex_handlers = []
-        for pattern, priority, handler, hid, timeout in self._regex:
-            if pattern and pattern.match(event_type):
-                regex_handlers.append((pattern, priority, handler, hid, timeout))
+        for _, _, handler, _, _ in handlers:
+            if event._propagation_stopped:
+                break
 
-        # 合并并排序（按优先级降序）
-        all_handlers = exact_handlers + prefix_handlers + regex_handlers
-        all_handlers.sort(key=lambda t: (-t[1], t[2].__name__))
-        return all_handlers
+            try:
+                result = await self._run_handler(handler, event)
+                event.add_result(result)
+            except Exception as exc:
+                LOG.exception("处理器 %s 执行失败: %s", handler.__name__, exc)
+                event.add_exception(exc)
 
-    # ==================== 生命周期 ====================
+        return event.results
 
-    def shutdown(self):
-        """关闭事件总线并清理资源"""
+    async def _run_handler(
+        self,
+        handler: Callable[[NcatBotEvent], Any],
+        event: NcatBotEvent,
+    ) -> Any:
+        result = handler(event)
+        if not isawaitable(result):
+            raise TypeError("EventBus 仅支持异步事件处理器")
+        return await result
+
+    def _collect_handlers(
+        self,
+        event_type: str,
+    ) -> List[Tuple[None, int, Callable[[NcatBotEvent], Any], uuid.UUID, float]]:
+        return list(self._exact.get(event_type, ()))
+
+    def _broadcast_adapter_event(self, event: BaseEvent) -> None:
+        for queue in tuple(self._stream_queues):
+            if queue.full():
+                try:
+                    queue.get_nowait()
+                    LOG.debug("事件流队列已满，已丢弃最旧事件")
+                except asyncio.QueueEmpty:
+                    pass
+            try:
+                queue.put_nowait(copy(event))
+            except Exception:
+                LOG.exception("写入事件流队列失败")
+
+    def _resolve_waiters(self, event: BaseEvent) -> None:
+        for waiter in tuple(self._waiters):
+            if waiter.future.done():
+                continue
+
+            try:
+                matched = bool(waiter.predicate(event))
+            except Exception as exc:
+                waiter.future.set_exception(exc)
+                continue
+
+            if matched:
+                waiter.future.set_result(copy(event))
+
+    def _remove_waiter(self, token: object) -> None:
+        for index, waiter in enumerate(self._waiters):
+            if waiter.token is token:
+                del self._waiters[index]
+                break
+
+    def _finalize_shutdown(self) -> None:
+        closed_error = RuntimeError("EventBus 已关闭")
+
+        for waiter in self._waiters:
+            if not waiter.future.done():
+                waiter.future.set_exception(closed_error)
+        self._waiters.clear()
+
+        for queue in tuple(self._stream_queues):
+            try:
+                queue.put_nowait(_STOP)
+            except Exception:
+                pass
+        self._stream_queues.clear()
+
+        while not self._incoming.empty():
+            try:
+                queued = self._incoming.get_nowait()
+            except asyncio.QueueEmpty:
+                break
+            if isinstance(queued, _QueuedEvent) and queued.completion is not None:
+                if not queued.completion.done():
+                    queued.completion.set_exception(closed_error)
+
+        self._dispatch_task = None
         self._exact.clear()
-        self._regex.clear()
         self._handler_meta.clear()
         self._loop = None
-        LOG.info("EventBus 已关闭，所有处理器已清理")
 
+    @staticmethod
+    def _is_async_handler(handler: Callable[[NcatBotEvent], Any]) -> bool:
+        return iscoroutinefunction(handler) or iscoroutinefunction(
+            getattr(handler, "__call__", None)
+        )
 
-@lru_cache(maxsize=128)
-def _compile_regex(pattern: str) -> re.Pattern:
-    """编译正则表达式并缓存"""
-    try:
-        return re.compile(pattern)
-    except re.error as e:
-        raise ValueError(f"无效正则表达式: {pattern}") from e
+    @staticmethod
+    def _get_event_type_from_event(event: BaseEvent) -> Optional[EventType]:
+        post_type = getattr(event, "post_type", None)
+        if post_type == PostType.MESSAGE or post_type == "message":
+            return EventType.MESSAGE
+        if post_type == PostType.MESSAGE_SENT or post_type == "message_sent":
+            return EventType.MESSAGE_SENT
+        if post_type == PostType.NOTICE or post_type == "notice":
+            return EventType.NOTICE
+        if post_type == PostType.REQUEST or post_type == "request":
+            return EventType.REQUEST
+        if post_type == PostType.META_EVENT or post_type == "meta_event":
+            return EventType.META
+        return None

--- a/ncatbot/core/client/lifecycle.py
+++ b/ncatbot/core/client/lifecycle.py
@@ -167,6 +167,10 @@ class LifecycleManager:
         if hasattr(self, "registry_engine") and self.registry_engine:
             self.registry_engine.clear()
 
+        # 5. 关闭事件总线
+        if self.event_bus:
+            await self.event_bus.close()
+
         LOG.info("Bot 资源已释放")
 
     # ================= 启动入口 =================

--- a/ncatbot/core/client/registry.py
+++ b/ncatbot/core/client/registry.py
@@ -9,7 +9,7 @@ NcatBot Event: 订阅的事件触发的回调是 NcatBotEvent(带类型 type 和
 --- CustomEvent
 """
 
-import inspect
+from inspect import iscoroutinefunction
 from typing import Callable, Optional, Type, Literal, TYPE_CHECKING, Union
 
 from ..event.enums import EventType
@@ -65,7 +65,7 @@ class EventRegistry:
             priority: 优先级，数值越大越先执行
             timeout: 超时时间
         """
-        key = event_type.value if isinstance(event_type, EventType) else event_type
+        key = self._normalize_event_type(event_type)
         self.event_bus.subscribe(key, handler, priority, timeout)
 
     def register_handler(
@@ -89,6 +89,8 @@ class EventRegistry:
             filter_func: 可选的过滤函数，接收 Event，返回 bool
         """
 
+        self._ensure_async_handler(handler)
+
         async def wrapper(ncatbot_event: NcatBotEvent):
             # 从 NcatBotEvent 提取真实的 Event
             event = ncatbot_event.data
@@ -98,10 +100,7 @@ class EventRegistry:
                 return
 
             # 调用用户的 handler
-            if inspect.iscoroutinefunction(handler):
-                await handler(event)
-            else:
-                handler(event)
+            await handler(event)
 
         self.subscribe(event_type, wrapper, priority, timeout)
 
@@ -249,8 +248,18 @@ class EventRegistry:
 
         def decorator(f):
             if notice_type:
-                # 直接使用 register_handler 而不是不存在的 _wrap_handler
-                self.register_handler(f"notice.{notice_type}", f, priority=priority)
+                def filter_func(event) -> bool:
+                    value = getattr(event, "notice_type", None)
+                    if hasattr(value, "value"):
+                        value = value.value
+                    return value == notice_type
+
+                self.register_handler(
+                    EventType.NOTICE,
+                    f,
+                    priority=priority,
+                    filter_func=filter_func,
+                )
             else:
                 self.add_notice_handler(f)
             return f
@@ -306,3 +315,15 @@ class EventRegistry:
             return f
 
         return decorator
+
+    @staticmethod
+    def _normalize_event_type(event_type: Union[str, EventType]) -> str:
+        if isinstance(event_type, EventType):
+            return f"ncatbot.{event_type.value}"
+        return event_type
+
+    @staticmethod
+    def _ensure_async_handler(handler: Callable) -> None:
+        if iscoroutinefunction(handler) or iscoroutinefunction(getattr(handler, "__call__", None)):
+            return
+        raise TypeError("EventRegistry 仅支持异步事件处理器")

--- a/ncatbot/plugin_system/builtin_plugin/system_manager.py
+++ b/ncatbot/plugin_system/builtin_plugin/system_manager.py
@@ -52,16 +52,22 @@ class SystemManager(NcatBotPlugin):
         self.register_handler("ncatbot.message_event", self._handle_message_event)
 
         # 订阅消息事件以触发命令和过滤器处理
-        self.event_bus.subscribe(
-            "re:ncatbot.message_event|ncatbot.message_sent_event",
-            self._handle_unified_registry_message,
-            timeout=900,
-        )
-        self.event_bus.subscribe(
-            "re:ncatbot.notice_event|ncatbot.request_event|ncatbot.meta_event",
-            self._handle_unified_registry_legacy,
-            timeout=900,
-        )
+        for event_type in ("ncatbot.message_event", "ncatbot.message_sent_event"):
+            self.event_bus.subscribe(
+                event_type,
+                self._handle_unified_registry_message,
+                timeout=900,
+            )
+        for event_type in (
+            "ncatbot.notice_event",
+            "ncatbot.request_event",
+            "ncatbot.meta_event",
+        ):
+            self.event_bus.subscribe(
+                event_type,
+                self._handle_unified_registry_legacy,
+                timeout=900,
+            )
 
         # 订阅插件文件变化事件（由 FileWatcherService 发布）
         self.event_bus.subscribe(

--- a/test/core/client/conftest.py
+++ b/test/core/client/conftest.py
@@ -19,13 +19,17 @@ from ncatbot.core.client.registry import EventRegistry
 @pytest.fixture
 def event_bus():
     """创建一个新的 EventBus 实例"""
-    return EventBus(default_timeout=5.0)
+    bus = EventBus(default_timeout=5.0)
+    yield bus
+    bus.shutdown()
 
 
 @pytest.fixture
 def event_bus_short_timeout():
     """创建一个短超时的 EventBus 实例（用于超时测试）"""
-    return EventBus(default_timeout=0.1)
+    bus = EventBus(default_timeout=0.1)
+    yield bus
+    bus.shutdown()
 
 
 # ==================== Mock Fixtures ====================

--- a/test/core/client/test_client.py
+++ b/test/core/client/test_client.py
@@ -2,6 +2,7 @@
 BotClient 集成测试
 """
 
+import asyncio
 import pytest
 from unittest.mock import MagicMock
 
@@ -102,7 +103,7 @@ class TestBotClientInheritance:
         async def handler(event):
             pass
 
-        assert "message_event" in client.event_bus._exact
+        assert "ncatbot.message_event" in client.event_bus._exact
 
 
 class TestBotClientPluginManagement:
@@ -185,4 +186,48 @@ class TestBotClientBuiltinHandlers:
 
         client = BotClient()
 
-        assert "meta_event" in client.event_bus._exact
+        assert "ncatbot.meta_event" in client.event_bus._exact
+
+
+class TestBotClientEventStream:
+    """测试 BotClient 事件流能力"""
+
+    @pytest.mark.asyncio
+    async def test_client_wait_event(self, mock_api, sample_message_event_data):
+        from ncatbot.core.client.client import BotClient
+        from ncatbot.core.event import EventParser
+
+        client = BotClient()
+        waiter = asyncio.create_task(
+            client.wait_event(lambda event: event.post_type == "message", timeout=1.0)
+        )
+
+        message_event = EventParser.parse(sample_message_event_data, mock_api)
+        await client.event_bus.on_adapter_event(message_event)
+
+        received = await waiter
+
+        assert received.raw_message == "Hello, world!"
+        await client.event_bus.close()
+
+    @pytest.mark.asyncio
+    async def test_client_async_for(self, mock_api, sample_message_event_data):
+        from ncatbot.core.client.client import BotClient
+        from ncatbot.core.event import EventParser
+
+        client = BotClient()
+
+        async def consume_one():
+            async for event in client:
+                return event
+            return None
+
+        consumer = asyncio.create_task(consume_one())
+
+        message_event = EventParser.parse(sample_message_event_data, mock_api)
+        await client.event_bus.on_adapter_event(message_event)
+
+        received = await asyncio.wait_for(consumer, timeout=1.0)
+
+        assert received.raw_message == "Hello, world!"
+        await client.event_bus.close()

--- a/test/core/client/test_dispatcher.py
+++ b/test/core/client/test_dispatcher.py
@@ -300,14 +300,14 @@ class TestEventDispatcherCallable:
             event_dispatcher.event_bus.subscribe("ncatbot.message_event", capture_call)
             await event_dispatcher(sample_message_event_data)
 
-            # 清除订阅
-            event_dispatcher.event_bus.shutdown()
+            # 使用新的 EventBus/Dispatcher 再调用 dispatch
+            from ncatbot.core.client.event_bus import EventBus
 
-            # 使用 dispatch
-            event_dispatcher.event_bus.subscribe(
-                "ncatbot.message_event", capture_dispatch
-            )
-            await event_dispatcher.dispatch(sample_message_event_data)
+            second_bus = EventBus()
+            second_bus.subscribe("ncatbot.message_event", capture_dispatch)
+            second_dispatcher = EventDispatcher(second_bus, event_dispatcher.api)
+            await second_dispatcher.dispatch(sample_message_event_data)
+            await second_bus.close()
 
         assert events_via_call == events_via_dispatch
 

--- a/test/core/client/test_event_bus_publish.py
+++ b/test/core/client/test_event_bus_publish.py
@@ -1,21 +1,20 @@
 """
-EventBus 发布和执行测试
+EventBus 发布、事件流和 waiter 测试
 """
 
 import asyncio
 
 import pytest
 
-from ncatbot.core.client.event_bus import HandlerTimeoutError
 from ncatbot.core import NcatBotEvent
+from ncatbot.core.event import EventParser, GroupMessageEvent
 
 
 class TestEventBusPublish:
-    """测试 EventBus 事件发布"""
+    """测试自定义事件发布"""
 
     @pytest.mark.asyncio
     async def test_publish_exact_match(self, event_bus):
-        """发布事件触发精确匹配处理器"""
         results = []
 
         async def handler(event):
@@ -25,58 +24,22 @@ class TestEventBusPublish:
         event_bus.subscribe("test.event", handler)
         event = NcatBotEvent("test.event", {"data": "test"})
 
-        await event_bus.publish(event)
+        publish_results = await event_bus.publish(event)
 
         assert results == ["test.event"]
+        assert publish_results == ["handled"]
         assert event.results == ["handled"]
-
-    @pytest.mark.asyncio
-    async def test_publish_prefix_match(self, event_bus):
-        """前缀匹配触发"""
-        results = []
-
-        async def prefix_handler(event):
-            results.append("prefix")
-            return "prefix_handled"
-
-        async def exact_handler(event):
-            results.append("exact")
-            return "exact_handled"
-
-        event_bus.subscribe("ncatbot.notice", prefix_handler)
-        event_bus.subscribe("ncatbot.notice.group_increase", exact_handler)
-
-        event = NcatBotEvent("ncatbot.notice.group_increase", {})
-        await event_bus.publish(event)
-
-        assert "exact" in results
-        assert "prefix" in results
-
-    @pytest.mark.asyncio
-    async def test_publish_regex_match(self, event_bus):
-        """正则匹配触发"""
-        results = []
-
-        async def handler(event):
-            results.append(event.type)
-
-        event_bus.subscribe("re:ncatbot\\.notice\\..*", handler)
-
-        event = NcatBotEvent("ncatbot.notice.group_increase", {})
-        await event_bus.publish(event)
-
-        assert results == ["ncatbot.notice.group_increase"]
+        await event_bus.close()
 
     @pytest.mark.asyncio
     async def test_publish_no_match(self, event_bus):
-        """无匹配处理器时正常返回"""
         event = NcatBotEvent("unmatched.event", {})
         results = await event_bus.publish(event)
         assert results == []
+        await event_bus.close()
 
     @pytest.mark.asyncio
     async def test_publish_multiple_handlers(self, event_bus):
-        """多个处理器都被调用"""
         call_order = []
 
         async def handler1(event):
@@ -95,6 +58,7 @@ class TestEventBusPublish:
 
         assert len(call_order) == 2
         assert set(results) == {1, 2}
+        await event_bus.close()
 
 
 class TestEventBusPriority:
@@ -102,7 +66,6 @@ class TestEventBusPriority:
 
     @pytest.mark.asyncio
     async def test_handler_priority_order(self, event_bus):
-        """高优先级处理器先执行"""
         call_order = []
 
         async def low_priority(event):
@@ -122,10 +85,10 @@ class TestEventBusPriority:
         await event_bus.publish(event)
 
         assert call_order == ["high", "medium", "low"]
+        await event_bus.close()
 
     @pytest.mark.asyncio
     async def test_stop_propagation_in_handler(self, event_bus):
-        """处理器中调用 stop_propagation()"""
         call_order = []
 
         async def first_handler(event):
@@ -142,54 +105,7 @@ class TestEventBusPriority:
         await event_bus.publish(event)
 
         assert call_order == ["first"]
-
-
-class TestEventBusTimeout:
-    """测试处理器超时"""
-
-    @pytest.mark.asyncio
-    async def test_handler_timeout(self, event_bus_short_timeout):
-        """处理器超时触发 HandlerTimeoutError"""
-
-        async def slow_handler(event):
-            await asyncio.sleep(0.12)
-            return "done"
-
-        event_bus_short_timeout.subscribe("test.event", slow_handler)
-
-        event = NcatBotEvent("test.event", {})
-        await event_bus_short_timeout.publish(event)
-
-        assert len(event.exceptions) == 1
-        assert isinstance(event.exceptions[0], HandlerTimeoutError)
-
-    @pytest.mark.asyncio
-    async def test_handler_custom_timeout(self, event_bus):
-        """自定义超时时间"""
-
-        async def slow_handler(event):
-            await asyncio.sleep(0.02)
-            return "done"
-
-        event_bus.subscribe("test.event", slow_handler, timeout=0.01)
-
-        event = NcatBotEvent("test.event", {})
-        await event_bus.publish(event)
-
-        assert len(event.exceptions) == 1
-        assert isinstance(event.exceptions[0], HandlerTimeoutError)
-
-    def test_handler_timeout_error_str(self):
-        """测试 HandlerTimeoutError 字符串表示"""
-        error = HandlerTimeoutError(
-            meta_data={"name": "TestPlugin"}, handler="test_handler", time=5.0
-        )
-
-        error_str = str(error)
-
-        assert "TestPlugin" in error_str
-        assert "test_handler" in error_str
-        assert "5" in error_str
+        await event_bus.close()
 
 
 class TestEventBusExceptionHandling:
@@ -197,8 +113,6 @@ class TestEventBusExceptionHandling:
 
     @pytest.mark.asyncio
     async def test_handler_exception_captured(self, event_bus):
-        """处理器异常被捕获到 event.exceptions"""
-
         async def failing_handler(event):
             raise ValueError("Handler error")
 
@@ -214,42 +128,77 @@ class TestEventBusExceptionHandling:
         assert len(event.exceptions) == 1
         assert isinstance(event.exceptions[0], ValueError)
         assert "ok" in results
+        await event_bus.close()
 
 
-class TestEventBusHandlerTypes:
-    """测试不同类型的处理器"""
-
-    @pytest.mark.asyncio
-    async def test_async_handler_execution(self, event_bus):
-        """异步处理器正确执行"""
-        result = []
-
-        async def async_handler(event):
-            await asyncio.sleep(0.01)
-            result.append("async")
-            return "async_result"
-
-        event_bus.subscribe("test.event", async_handler)
-
-        event = NcatBotEvent("test.event", {})
-        results = await event_bus.publish(event)
-
-        assert result == ["async"]
-        assert "async_result" in results
+class TestEventBusAdapterStream:
+    """测试 adapter 事件入口、流式消费和 wait_event"""
 
     @pytest.mark.asyncio
-    async def test_sync_handler_execution(self, event_bus):
-        """同步处理器正确执行"""
-        result = []
+    async def test_on_adapter_event_dispatches_normalized_event(
+        self, event_bus, mock_api, sample_message_event_data
+    ):
+        handled = asyncio.Event()
+        seen_types = []
 
-        def sync_handler(event):
-            result.append("sync")
-            return "sync_result"
+        async def handler(event):
+            seen_types.append(event.type)
+            handled.set()
 
-        event_bus.subscribe("test.event", sync_handler)
+        event_bus.subscribe("ncatbot.message_event", handler)
+        message_event = EventParser.parse(sample_message_event_data, mock_api)
 
-        event = NcatBotEvent("test.event", {})
-        results = await event_bus.publish(event)
+        await event_bus.on_adapter_event(message_event)
+        await asyncio.wait_for(handled.wait(), timeout=1.0)
 
-        assert result == ["sync"]
-        assert "sync_result" in results
+        assert seen_types == ["ncatbot.message_event"]
+        await event_bus.close()
+
+    @pytest.mark.asyncio
+    async def test_wait_event_returns_matching_adapter_event(
+        self, event_bus, mock_api, sample_message_event_data
+    ):
+        waiter = asyncio.create_task(
+            event_bus.wait_event(lambda event: event.post_type == "message", timeout=1.0)
+        )
+
+        message_event = EventParser.parse(sample_message_event_data, mock_api)
+        await event_bus.on_adapter_event(message_event)
+
+        received = await waiter
+
+        assert isinstance(received, GroupMessageEvent)
+        assert received.raw_message == "Hello, world!"
+        await event_bus.close()
+
+    @pytest.mark.asyncio
+    async def test_async_iterator_yields_adapter_events(
+        self, event_bus, mock_api, sample_message_event_data
+    ):
+        async def consume_one():
+            async for event in event_bus:
+                return event
+            return None
+
+        consumer = asyncio.create_task(consume_one())
+
+        message_event = EventParser.parse(sample_message_event_data, mock_api)
+        await event_bus.on_adapter_event(message_event)
+
+        received = await asyncio.wait_for(consumer, timeout=1.0)
+
+        assert isinstance(received, GroupMessageEvent)
+        assert received.group_id == "123456789"
+        await event_bus.close()
+
+    @pytest.mark.asyncio
+    async def test_custom_publish_does_not_match_adapter_waiter(self, event_bus):
+        waiter = asyncio.create_task(
+            event_bus.wait_event(lambda event: event.post_type == "message", timeout=0.05)
+        )
+
+        with pytest.raises(asyncio.TimeoutError):
+            await event_bus.publish(NcatBotEvent("test.event", {}))
+            await waiter
+
+        await event_bus.close()

--- a/test/core/client/test_event_bus_subscribe.py
+++ b/test/core/client/test_event_bus_subscribe.py
@@ -1,5 +1,5 @@
 """
-EventBus 订阅和取消订阅测试
+EventBus 订阅和生命周期测试
 """
 
 import uuid
@@ -7,17 +7,13 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from ncatbot.core.client.event_bus import _compile_regex
-
 
 class TestEventBusSubscription:
     """测试 EventBus 订阅管理"""
 
     def test_subscribe_exact_match(self, event_bus):
-        """精确匹配订阅"""
-
         async def handler(event):
-            pass
+            return None
 
         handler_id = event_bus.subscribe("test.event", handler)
 
@@ -25,25 +21,12 @@ class TestEventBusSubscription:
         assert "test.event" in event_bus._exact
         assert len(event_bus._exact["test.event"]) == 1
 
-    def test_subscribe_regex_match(self, event_bus):
-        """正则匹配订阅"""
-
-        async def handler(event):
-            pass
-
-        handler_id = event_bus.subscribe("re:test\\..*", handler)
-
-        assert isinstance(handler_id, uuid.UUID)
-        assert len(event_bus._regex) == 1
-
     def test_subscribe_returns_unique_uuid(self, event_bus):
-        """订阅返回唯一 UUID"""
-
         async def handler1(event):
-            pass
+            return None
 
         async def handler2(event):
-            pass
+            return None
 
         id1 = event_bus.subscribe("test.event", handler1)
         id2 = event_bus.subscribe("test.event", handler2)
@@ -51,13 +34,11 @@ class TestEventBusSubscription:
         assert id1 != id2
 
     def test_subscribe_with_priority(self, event_bus):
-        """带优先级的订阅"""
-
         async def handler1(event):
-            pass
+            return None
 
         async def handler2(event):
-            pass
+            return None
 
         event_bus.subscribe("test.event", handler1, priority=1)
         event_bus.subscribe("test.event", handler2, priority=10)
@@ -66,20 +47,9 @@ class TestEventBusSubscription:
         assert handlers[0][1] == 10
         assert handlers[1][1] == 1
 
-    def test_subscribe_with_custom_timeout(self, event_bus):
-        """自定义超时时间"""
-
-        async def handler(event):
-            pass
-
-        event_bus.subscribe("test.event", handler, timeout=30.0)
-        assert event_bus._exact["test.event"][0][4] == 30.0
-
     def test_subscribe_with_plugin_metadata(self, event_bus):
-        """带插件元数据的订阅"""
-
         async def handler(event):
-            pass
+            return None
 
         plugin = MagicMock()
         plugin.meta_data = {"name": "TestPlugin", "version": "1.0"}
@@ -89,15 +59,27 @@ class TestEventBusSubscription:
         assert handler_id in event_bus._handler_meta
         assert event_bus._handler_meta[handler_id]["name"] == "TestPlugin"
 
+    def test_subscribe_rejects_regex(self, event_bus):
+        async def handler(event):
+            return None
+
+        with pytest.raises(ValueError, match="不再支持正则"):
+            event_bus.subscribe("re:test\\..*", handler)
+
+    def test_subscribe_rejects_sync_handler(self, event_bus):
+        def handler(event):
+            return None
+
+        with pytest.raises(TypeError, match="仅支持异步事件处理器"):
+            event_bus.subscribe("test.event", handler)
+
 
 class TestEventBusUnsubscribe:
     """测试 EventBus 取消订阅"""
 
     def test_unsubscribe_by_uuid(self, event_bus):
-        """通过 UUID 取消订阅"""
-
         async def handler(event):
-            pass
+            return None
 
         handler_id = event_bus.subscribe("test.event", handler)
         result = event_bus.unsubscribe(handler_id)
@@ -106,111 +88,40 @@ class TestEventBusUnsubscribe:
         assert "test.event" not in event_bus._exact
 
     def test_unsubscribe_nonexistent(self, event_bus):
-        """取消不存在的订阅返回 False"""
         fake_id = uuid.uuid4()
         result = event_bus.unsubscribe(fake_id)
         assert result is False
 
-    def test_unsubscribe_regex_handler(self, event_bus):
-        """取消正则订阅"""
-
-        async def handler(event):
-            pass
-
-        handler_id = event_bus.subscribe("re:test\\..*", handler)
-        assert len(event_bus._regex) == 1
-
-        result = event_bus.unsubscribe(handler_id)
-
-        assert result is True
-        assert len(event_bus._regex) == 0
-
     def test_unsubscribe_cleans_metadata(self, event_bus):
-        """取消订阅时清理元数据"""
-
         async def handler(event):
-            pass
+            return None
 
         plugin = MagicMock()
         plugin.meta_data = {"name": "TestPlugin"}
         handler_id = event_bus.subscribe("test.event", handler, plugin=plugin)
-
-        assert handler_id in event_bus._handler_meta
 
         event_bus.unsubscribe(handler_id)
 
         assert handler_id not in event_bus._handler_meta
 
 
-class TestCompileRegex:
-    """测试正则表达式编译"""
-
-    def test_compile_valid_regex(self):
-        """编译有效正则"""
-        pattern = _compile_regex(r"test\..*")
-
-        assert pattern.match("test.event")
-        assert pattern.match("test.another")
-        assert not pattern.match("other.event")
-
-    def test_compile_invalid_regex(self):
-        """编译无效正则抛出异常"""
-        with pytest.raises(ValueError, match="无效正则表达式"):
-            _compile_regex(r"[invalid")
-
-    def test_compile_regex_cached(self):
-        """正则编译被缓存"""
-        pattern1 = _compile_regex(r"test\..*")
-        pattern2 = _compile_regex(r"test\..*")
-        assert pattern1 is pattern2
-
-
 class TestEventBusCollectHandlers:
     """测试处理器收集"""
 
     def test_collect_exact_handlers(self, event_bus):
-        """收集精确匹配处理器"""
-
         async def handler(event):
-            pass
+            return None
 
         event_bus.subscribe("test.event", handler)
         handlers = event_bus._collect_handlers("test.event")
         assert len(handlers) == 1
 
-    def test_collect_prefix_handlers(self, event_bus):
-        """收集前缀匹配处理器"""
-
-        async def handler1(event):
-            pass
-
-        async def handler2(event):
-            pass
-
-        event_bus.subscribe("ncatbot", handler1)
-        event_bus.subscribe("ncatbot.notice", handler2)
-
-        handlers = event_bus._collect_handlers("ncatbot.notice.group")
-        assert len(handlers) == 2
-
-    def test_collect_regex_handlers(self, event_bus):
-        """收集正则匹配处理器"""
-
-        async def handler(event):
-            pass
-
-        event_bus.subscribe("re:ncatbot\\.notice\\..*", handler)
-        handlers = event_bus._collect_handlers("ncatbot.notice.group_increase")
-        assert len(handlers) == 1
-
     def test_collect_handlers_sorted_by_priority(self, event_bus):
-        """收集的处理器按优先级排序"""
-
         async def handler_low(event):
-            pass
+            return None
 
         async def handler_high(event):
-            pass
+            return None
 
         event_bus.subscribe("test.event", handler_low, priority=1)
         event_bus.subscribe("test.event", handler_high, priority=100)
@@ -224,23 +135,18 @@ class TestEventBusLifecycle:
     """测试 EventBus 生命周期"""
 
     def test_shutdown_clears_handlers(self, event_bus):
-        """shutdown() 清理所有处理器"""
-
         async def handler(event):
-            pass
+            return None
 
         plugin = MagicMock()
         plugin.meta_data = {"name": "Test"}
 
         event_bus.subscribe("test.event", handler, plugin=plugin)
-        event_bus.subscribe("re:test\\..*", handler)
 
         assert len(event_bus._exact) > 0
-        assert len(event_bus._regex) > 0
         assert len(event_bus._handler_meta) > 0
 
         event_bus.shutdown()
 
         assert len(event_bus._exact) == 0
-        assert len(event_bus._regex) == 0
         assert len(event_bus._handler_meta) == 0

--- a/test/core/client/test_registry_core.py
+++ b/test/core/client/test_registry_core.py
@@ -29,7 +29,7 @@ class TestEventRegistrySubscribe:
             pass
 
         event_registry.subscribe(EventType.MESSAGE, handler)
-        assert "message_event" in event_registry.event_bus._exact
+        assert "ncatbot.message_event" in event_registry.event_bus._exact
 
     def test_subscribe_with_string(self, event_registry):
         """使用字符串订阅"""
@@ -76,7 +76,7 @@ class TestEventRegistryRegisterHandler:
 
         mock_event_data = MagicMock()
         mock_event_data.user_id = 12345
-        ncatbot_event = NcatBotEvent("message_event", mock_event_data)
+        ncatbot_event = NcatBotEvent("ncatbot.message_event", mock_event_data)
 
         await event_registry.event_bus.publish(ncatbot_event)
 
@@ -101,33 +101,26 @@ class TestEventRegistryRegisterHandler:
         # 发布被过滤的事件
         mock_event1 = MagicMock()
         mock_event1.user_id = 500
-        ncatbot_event1 = NcatBotEvent("message_event", mock_event1)
+        ncatbot_event1 = NcatBotEvent("ncatbot.message_event", mock_event1)
         await event_registry.event_bus.publish(ncatbot_event1)
 
         # 发布通过过滤的事件
         mock_event2 = MagicMock()
         mock_event2.user_id = 2000
-        ncatbot_event2 = NcatBotEvent("message_event", mock_event2)
+        ncatbot_event2 = NcatBotEvent("ncatbot.message_event", mock_event2)
         await event_registry.event_bus.publish(ncatbot_event2)
 
         assert len(received_data) == 1
         assert received_data[0].user_id == 2000
 
-    @pytest.mark.asyncio
-    async def test_register_handler_sync_handler(self, event_registry):
-        """同步处理器正确执行"""
-        received_data = []
+    def test_register_handler_rejects_sync_handler(self, event_registry):
+        """同步处理器会在注册时被拒绝"""
 
         def sync_handler(event):
-            received_data.append(event)
+            return None
 
-        event_registry.register_handler(EventType.MESSAGE, sync_handler)
-
-        mock_event_data = MagicMock()
-        ncatbot_event = NcatBotEvent("message_event", mock_event_data)
-        await event_registry.event_bus.publish(ncatbot_event)
-
-        assert len(received_data) == 1
+        with pytest.raises(TypeError, match="仅支持异步事件处理器"):
+            event_registry.register_handler(EventType.MESSAGE, sync_handler)
 
 
 class TestEventRegistryAddHandler:

--- a/test/core/client/test_registry_decorators.py
+++ b/test/core/client/test_registry_decorators.py
@@ -18,7 +18,7 @@ class TestEventRegistryDecorators:
         async def handler(event):
             pass
 
-        assert "message_event" in event_registry.event_bus._exact
+        assert "ncatbot.message_event" in event_registry.event_bus._exact
 
     def test_on_group_message_returns_function(self, event_registry):
         """装饰器返回原函数"""
@@ -36,7 +36,7 @@ class TestEventRegistryDecorators:
         async def handler(event):
             pass
 
-        assert "message_event" in event_registry.event_bus._exact
+        assert "ncatbot.message_event" in event_registry.event_bus._exact
 
     def test_on_notice_decorator(self, event_registry):
         """@on_notice() 装饰器"""
@@ -45,7 +45,7 @@ class TestEventRegistryDecorators:
         async def handler(event):
             pass
 
-        assert "notice_event" in event_registry.event_bus._exact
+        assert "ncatbot.notice_event" in event_registry.event_bus._exact
 
     def test_on_notice_with_type(self, event_registry):
         """@on_notice(notice_type="group_increase")"""
@@ -54,7 +54,7 @@ class TestEventRegistryDecorators:
         async def handler(event):
             pass
 
-        assert "notice.group_increase" in event_registry.event_bus._exact
+        assert "ncatbot.notice_event" in event_registry.event_bus._exact
 
     def test_on_request_decorator_deprecated(self, event_registry):
         """@on_request() 弃用装饰器"""
@@ -63,7 +63,7 @@ class TestEventRegistryDecorators:
         async def handler(event):
             pass
 
-        assert "request_event" in event_registry.event_bus._exact
+        assert "ncatbot.request_event" in event_registry.event_bus._exact
 
     def test_on_group_request_decorator(self, event_registry):
         """@on_group_request() 装饰器"""
@@ -72,7 +72,7 @@ class TestEventRegistryDecorators:
         async def handler(event):
             pass
 
-        assert "request_event" in event_registry.event_bus._exact
+        assert "ncatbot.request_event" in event_registry.event_bus._exact
 
     def test_on_friend_request_decorator(self, event_registry):
         """@on_friend_request() 装饰器"""
@@ -81,7 +81,7 @@ class TestEventRegistryDecorators:
         async def handler(event):
             pass
 
-        assert "request_event" in event_registry.event_bus._exact
+        assert "ncatbot.request_event" in event_registry.event_bus._exact
 
     def test_on_startup_decorator(self, event_registry):
         """@on_startup() 装饰器"""
@@ -90,7 +90,7 @@ class TestEventRegistryDecorators:
         async def handler(event):
             pass
 
-        assert "meta_event" in event_registry.event_bus._exact
+        assert "ncatbot.meta_event" in event_registry.event_bus._exact
 
     def test_on_shutdown_decorator(self, event_registry):
         """@on_shutdown() 装饰器"""
@@ -99,7 +99,7 @@ class TestEventRegistryDecorators:
         async def handler(event):
             pass
 
-        assert "meta_event" in event_registry.event_bus._exact
+        assert "ncatbot.meta_event" in event_registry.event_bus._exact
 
     def test_on_heartbeat_decorator(self, event_registry):
         """@on_heartbeat() 装饰器"""
@@ -108,7 +108,7 @@ class TestEventRegistryDecorators:
         async def handler(event):
             pass
 
-        assert "meta_event" in event_registry.event_bus._exact
+        assert "ncatbot.meta_event" in event_registry.event_bus._exact
 
     def test_on_message_sent_decorator(self, event_registry):
         """@on_message_sent() 装饰器"""
@@ -117,7 +117,7 @@ class TestEventRegistryDecorators:
         async def handler(event):
             pass
 
-        assert "message_sent_event" in event_registry.event_bus._exact
+        assert "ncatbot.message_sent_event" in event_registry.event_bus._exact
 
 
 class TestEventRegistryIntegration:
@@ -138,7 +138,7 @@ class TestEventRegistryIntegration:
 
         mock_event = MagicMock()
         mock_event.message_type = "group"
-        ncatbot_event = NcatBotEvent("message_event", mock_event)
+        ncatbot_event = NcatBotEvent("ncatbot.message_event", mock_event)
 
         await event_registry.event_bus.publish(ncatbot_event)
 
@@ -162,7 +162,7 @@ class TestEventRegistryIntegration:
         mock_event.message = MagicMock()
         mock_event.message.filter = MagicMock(return_value=[MagicMock()])
 
-        ncatbot_event = NcatBotEvent("message_event", mock_event)
+        ncatbot_event = NcatBotEvent("ncatbot.message_event", mock_event)
         await event_registry.event_bus.publish(ncatbot_event)
 
         assert len(results) == 1

--- a/test/core/client/test_registry_handlers.py
+++ b/test/core/client/test_registry_handlers.py
@@ -23,7 +23,7 @@ class TestEventRegistryMessageHandlers:
 
         event_registry.add_group_message_handler(handler)
 
-        ncatbot_event = NcatBotEvent("message_event", mock_group_message_event)
+        ncatbot_event = NcatBotEvent("ncatbot.message_event", mock_group_message_event)
         await event_registry.event_bus.publish(ncatbot_event)
 
         assert len(received) == 1
@@ -40,7 +40,7 @@ class TestEventRegistryMessageHandlers:
 
         event_registry.add_group_message_handler(handler)
 
-        ncatbot_event = NcatBotEvent("message_event", mock_private_message_event)
+        ncatbot_event = NcatBotEvent("ncatbot.message_event", mock_private_message_event)
         await event_registry.event_bus.publish(ncatbot_event)
 
         assert len(received) == 0
@@ -57,7 +57,7 @@ class TestEventRegistryMessageHandlers:
 
         event_registry.add_private_message_handler(handler)
 
-        ncatbot_event = NcatBotEvent("message_event", mock_private_message_event)
+        ncatbot_event = NcatBotEvent("ncatbot.message_event", mock_private_message_event)
         await event_registry.event_bus.publish(ncatbot_event)
 
         assert len(received) == 1
@@ -74,7 +74,7 @@ class TestEventRegistryMessageHandlers:
 
         event_registry.add_private_message_handler(handler)
 
-        ncatbot_event = NcatBotEvent("message_event", mock_group_message_event)
+        ncatbot_event = NcatBotEvent("ncatbot.message_event", mock_group_message_event)
         await event_registry.event_bus.publish(ncatbot_event)
 
         assert len(received) == 0
@@ -96,7 +96,7 @@ class TestEventRegistryMessageHandlers:
 
         event_registry.add_group_message_handler(handler, filter=MessageSegment)
 
-        ncatbot_event = NcatBotEvent("message_event", mock_event)
+        ncatbot_event = NcatBotEvent("ncatbot.message_event", mock_event)
         await event_registry.event_bus.publish(ncatbot_event)
 
         assert len(received) == 1
@@ -115,7 +115,7 @@ class TestEventRegistryNoticeHandler:
 
         event_registry.add_notice_handler(handler)
 
-        ncatbot_event = NcatBotEvent("notice_event", mock_notice_event)
+        ncatbot_event = NcatBotEvent("ncatbot.notice_event", mock_notice_event)
         await event_registry.event_bus.publish(ncatbot_event)
 
         assert len(received) == 1
@@ -136,7 +136,7 @@ class TestEventRegistryRequestHandlers:
 
         event_registry.add_group_request_handler(handler)
 
-        ncatbot_event = NcatBotEvent("request_event", mock_group_request_event)
+        ncatbot_event = NcatBotEvent("ncatbot.request_event", mock_group_request_event)
         await event_registry.event_bus.publish(ncatbot_event)
 
         assert len(received) == 1
@@ -153,7 +153,7 @@ class TestEventRegistryRequestHandlers:
 
         event_registry.add_friend_request_handler(handler)
 
-        ncatbot_event = NcatBotEvent("request_event", mock_friend_request_event)
+        ncatbot_event = NcatBotEvent("ncatbot.request_event", mock_friend_request_event)
         await event_registry.event_bus.publish(ncatbot_event)
 
         assert len(received) == 1
@@ -170,7 +170,7 @@ class TestEventRegistryRequestHandlers:
 
         event_registry.add_group_request_handler(handler)
 
-        ncatbot_event = NcatBotEvent("request_event", mock_friend_request_event)
+        ncatbot_event = NcatBotEvent("ncatbot.request_event", mock_friend_request_event)
         await event_registry.event_bus.publish(ncatbot_event)
 
         assert len(received) == 0
@@ -182,7 +182,7 @@ class TestEventRegistryRequestHandlers:
             pass
 
         event_registry.add_request_handler(handler, filter="group")
-        assert "request_event" in event_registry.event_bus._exact
+        assert "ncatbot.request_event" in event_registry.event_bus._exact
 
     def test_add_request_handler_deprecated_friend(self, event_registry):
         """弃用的 add_request_handler 好友过滤"""
@@ -191,7 +191,7 @@ class TestEventRegistryRequestHandlers:
             pass
 
         event_registry.add_request_handler(handler, filter="friend")
-        assert "request_event" in event_registry.event_bus._exact
+        assert "ncatbot.request_event" in event_registry.event_bus._exact
 
 
 class TestEventRegistryMetaHandlers:
@@ -207,7 +207,7 @@ class TestEventRegistryMetaHandlers:
 
         event_registry.add_startup_handler(handler)
 
-        ncatbot_event = NcatBotEvent("meta_event", mock_startup_event)
+        ncatbot_event = NcatBotEvent("ncatbot.meta_event", mock_startup_event)
         await event_registry.event_bus.publish(ncatbot_event)
 
         assert len(received) == 1
@@ -222,7 +222,7 @@ class TestEventRegistryMetaHandlers:
 
         event_registry.add_heartbeat_handler(handler)
 
-        ncatbot_event = NcatBotEvent("meta_event", mock_heartbeat_event)
+        ncatbot_event = NcatBotEvent("ncatbot.meta_event", mock_heartbeat_event)
         await event_registry.event_bus.publish(ncatbot_event)
 
         assert len(received) == 1
@@ -239,7 +239,7 @@ class TestEventRegistryMetaHandlers:
 
         event_registry.add_startup_handler(handler)
 
-        ncatbot_event = NcatBotEvent("meta_event", mock_heartbeat_event)
+        ncatbot_event = NcatBotEvent("ncatbot.meta_event", mock_heartbeat_event)
         await event_registry.event_bus.publish(ncatbot_event)
 
         assert len(received) == 0

--- a/test/integration/conftest.py
+++ b/test/integration/conftest.py
@@ -184,7 +184,9 @@ class TestPlugin:
 @pytest.fixture
 def event_bus():
     """创建事件总线"""
-    return EventBus(default_timeout=10.0)
+    bus = EventBus(default_timeout=10.0)
+    yield bus
+    bus.shutdown()
 
 
 @pytest.fixture

--- a/test/integration/test_event_pipeline.py
+++ b/test/integration/test_event_pipeline.py
@@ -46,7 +46,7 @@ class TestEventPipelineBasic:
         """测试消息事件完整流水线"""
         received_events: List[NcatBotEvent] = []
 
-        def handler(event: NcatBotEvent):
+        async def handler(event: NcatBotEvent):
             received_events.append(event)
 
         # 订阅消息事件
@@ -70,7 +70,10 @@ class TestEventPipelineBasic:
         """测试私聊消息流水线"""
         received = []
 
-        event_bus.subscribe(MESSAGE_EVENT, lambda e: received.append(e))
+        async def handler(event):
+            received.append(event)
+
+        event_bus.subscribe(MESSAGE_EVENT, handler)
 
         dispatcher = EventDispatcher(event_bus, mock_api)
         await dispatcher.dispatch(sample_private_message_event)
@@ -86,7 +89,10 @@ class TestEventPipelineBasic:
         """测试通知事件流水线"""
         received = []
 
-        event_bus.subscribe(NOTICE_EVENT, lambda e: received.append(e))
+        async def handler(event):
+            received.append(event)
+
+        event_bus.subscribe(NOTICE_EVENT, handler)
 
         dispatcher = EventDispatcher(event_bus, mock_api)
         await dispatcher.dispatch(sample_notice_event)
@@ -101,7 +107,10 @@ class TestEventPipelineBasic:
         """测试请求事件流水线"""
         received = []
 
-        event_bus.subscribe(REQUEST_EVENT, lambda e: received.append(e))
+        async def handler(event):
+            received.append(event)
+
+        event_bus.subscribe(REQUEST_EVENT, handler)
 
         dispatcher = EventDispatcher(event_bus, mock_api)
         await dispatcher.dispatch(sample_request_event)
@@ -114,7 +123,10 @@ class TestEventPipelineBasic:
         """测试元事件流水线"""
         received = []
 
-        event_bus.subscribe(META_EVENT, lambda e: received.append(e))
+        async def handler(event):
+            received.append(event)
+
+        event_bus.subscribe(META_EVENT, handler)
 
         dispatcher = EventDispatcher(event_bus, mock_api)
         await dispatcher.dispatch(sample_meta_event)
@@ -137,13 +149,13 @@ class TestMultipleHandlers:
         """测试多个处理器都被调用"""
         call_order = []
 
-        def handler1(e):
+        async def handler1(e):
             call_order.append("handler1")
 
-        def handler2(e):
+        async def handler2(e):
             call_order.append("handler2")
 
-        def handler3(e):
+        async def handler3(e):
             call_order.append("handler3")
 
         event_bus.subscribe(MESSAGE_EVENT, handler1)
@@ -165,13 +177,13 @@ class TestMultipleHandlers:
         """测试处理器按优先级执行"""
         call_order = []
 
-        def low_priority(e):
+        async def low_priority(e):
             call_order.append("low")
 
-        def high_priority(e):
+        async def high_priority(e):
             call_order.append("high")
 
-        def medium_priority(e):
+        async def medium_priority(e):
             call_order.append("medium")
 
         # 不同优先级注册
@@ -219,13 +231,13 @@ class TestHandlerExceptions:
         """测试一个处理器异常不影响其他处理器"""
         results = []
 
-        def good_handler1(e):
+        async def good_handler1(e):
             results.append("good1")
 
-        def bad_handler(e):
+        async def bad_handler(e):
             raise ValueError("Handler error")
 
-        def good_handler2(e):
+        async def good_handler2(e):
             results.append("good2")
 
         # 高优先级的好处理器

--- a/test/integration/test_plugin_integration.py
+++ b/test/integration/test_plugin_integration.py
@@ -93,9 +93,9 @@ class GreeterPlugin(MockBasePlugin):
     async def on_load(self):
         await super().on_load()
         # 注册消息处理器
-        self.register_handler("ncatbot.message", self._on_message)
+        self.register_handler("ncatbot.message_event", self._on_message)
 
-    def _on_message(self, event: NcatBotEvent):
+    async def _on_message(self, event: NcatBotEvent):
         self.events_received.append(event)
         self.greet_count += 1
 
@@ -112,10 +112,9 @@ class LoggerPlugin(MockBasePlugin):
 
     async def on_load(self):
         await super().on_load()
-        # 注册所有事件
-        self.register_handler("re:ncatbot\\..*", self._log_event, priority=1000)
+        self.register_handler("ncatbot.message_event", self._log_event, priority=1000)
 
-    def _log_event(self, event: NcatBotEvent):
+    async def _log_event(self, event: NcatBotEvent):
         self.log_entries.append(f"[{event.type}] received")
 
 
@@ -192,7 +191,7 @@ class TestPluginEventHandling:
         await plugin.on_load()
 
         # 发布事件
-        event = NcatBotEvent("ncatbot.message", MagicMock())
+        event = NcatBotEvent("ncatbot.message_event", MagicMock())
         await event_bus.publish(event)
 
         assert plugin.greet_count == 1


### PR DESCRIPTION
## 背景

这次改动按“重构 client 的 event_bus，不考虑兼容性，并放弃同步支持”的方向推进，目标是把事件链路收敛到统一的异步事件流模型，并直接承接 adapter 上报的标准事件。

## 主要改动

- 重构 `EventBus`，改为单队列 + 单分发协程的异步事件中枢
- 新增 `on_adapter_event()`，作为 adapter 事件回调入口
- 为 `EventBus` 和 `BotClient` 增加 `events()`、`async for`、`wait_event()` 能力
- 将 `BotClient` 的 adapter 回调直接绑定到 `event_bus.on_adapter_event`
- 保留 `EventDispatcher` 作为薄桥接层，主要用于 dict 解析和测试场景
- 移除正则事件订阅，统一为精确事件名订阅
- 统一 `EventRegistry` 的事件名为 `ncatbot.*`
- `on_notice(notice_type=...)` 改为通过过滤器细分
- 事件处理器改为仅支持异步函数
- 同步更新 `SystemManager` 和相关测试，适配新的事件总线语义

## 验证

已执行：

- `pytest -q -o addopts='' test/core/client/test_event_bus_publish.py test/core/client/test_event_bus_subscribe.py test/core/client/test_dispatcher.py test/core/client/test_client.py test/core/client/test_registry_core.py test/core/client/test_registry_handlers.py test/core/client/test_registry_decorators.py test/core/client/test_lifecycle.py`
- `pytest -q -o addopts='' test/integration/test_event_pipeline.py test/integration/test_plugin_integration.py`

## 说明

- 这次重构明确按异步模型收敛，不再支持正则事件订阅
- 事件处理器现在要求必须为异步函数
- `BotClient` 现在支持 `async for` 和 `wait_event`
