### PR TITLE
feat: add Java SDK for NcatBot plugin development

### DIFF
--- a/ncatbot-java-sdk/pom.xml
+++ b/ncatbot-java-sdk/pom.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>xyz.ncatbot</groupId>
+    <artifactId>ncatbot-java-plugin</artifactId>
+    <version>1.0.0</version>
+    <packaging>jar</packaging>
+
+    <name>NcatBot Java Plugin SDK</name>
+    <description>NcatBot Java 插件 SDK 与示例插件</description>
+
+    <properties>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.17.2</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.13.0</version>
+                <configuration>
+                    <release>17</release>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.6.0</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <createDependencyReducedPom>false</createDependencyReducedPom>
+                            <transformers>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                    <mainClass>xyz.ncatbot.java.example.ExamplePluginMain</mainClass>
+                                </transformer>
+                            </transformers>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/ncatbot-java-sdk/src/main/java/xyz/ncatbot/java/example/ExamplePluginMain.java
+++ b/ncatbot-java-sdk/src/main/java/xyz/ncatbot/java/example/ExamplePluginMain.java
@@ -1,0 +1,9 @@
+package xyz.ncatbot.java.example;
+
+import xyz.ncatbot.java.sdk.NcatBotJavaRuntime;
+
+public class ExamplePluginMain {
+    public static void main(String[] args) throws Exception {
+        NcatBotJavaRuntime.run(args);
+    }
+}

--- a/ncatbot-java-sdk/src/main/java/xyz/ncatbot/java/example/HelloPlugin.java
+++ b/ncatbot-java-sdk/src/main/java/xyz/ncatbot/java/example/HelloPlugin.java
@@ -1,0 +1,33 @@
+package xyz.ncatbot.java.example;
+
+import xyz.ncatbot.java.sdk.NcatBotContext;
+import xyz.ncatbot.java.sdk.NcatBotEvent;
+import xyz.ncatbot.java.sdk.NcatBotPlugin;
+
+/**
+ * 示例插件：收到 hello 后回复 hi from java。
+ */
+public class HelloPlugin implements NcatBotPlugin {
+    private NcatBotContext context;
+
+    @Override
+    public void onLoad(NcatBotContext context) {
+        this.context = context;
+        System.out.println("HelloPlugin 已加载: " + context.getPluginName());
+    }
+
+    @Override
+    public void onEvent(NcatBotEvent event) throws Exception {
+        if (!"hello".equalsIgnoreCase(event.getText().trim())) {
+            return;
+        }
+
+        Long groupId = event.getGroupId();
+        Long userId = event.getUserId();
+        if (groupId != null) {
+            context.getBotApi().sendGroupText(groupId, "hi from java");
+        } else if (userId != null) {
+            context.getBotApi().sendPrivateText(userId, "hi from java");
+        }
+    }
+}

--- a/ncatbot-java-sdk/src/main/java/xyz/ncatbot/java/sdk/BotApi.java
+++ b/ncatbot-java-sdk/src/main/java/xyz/ncatbot/java/sdk/BotApi.java
@@ -1,0 +1,96 @@
+package xyz.ncatbot.java.sdk;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.Collections;
+import java.util.Map;
+
+/**
+ * 调用 Python 桥接插件 /api/call 的简单客户端。
+ */
+public class BotApi {
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private final HttpClient httpClient;
+    private final String apiUrl;
+    private final String token;
+
+    public BotApi(String apiUrl, String token) {
+        this.apiUrl = stripTrailingSlash(apiUrl);
+        this.token = token == null ? "" : token;
+        this.httpClient = HttpClient.newBuilder()
+                .connectTimeout(Duration.ofSeconds(10))
+                .build();
+    }
+
+    public JsonNode call(String action, Map<String, ?> params) throws IOException, InterruptedException {
+        ObjectNode body = MAPPER.createObjectNode();
+        body.put("action", action);
+        body.set("params", MAPPER.valueToTree(params == null ? Collections.emptyMap() : params));
+
+        HttpRequest.Builder builder = HttpRequest.newBuilder()
+                .uri(URI.create(apiUrl + "/api/call"))
+                .timeout(Duration.ofSeconds(30))
+                .header("Content-Type", "application/json")
+                .POST(HttpRequest.BodyPublishers.ofString(MAPPER.writeValueAsString(body)));
+        if (!token.isBlank()) {
+            builder.header("Authorization", "Bearer " + token);
+            builder.header("X-NcatBot-Token", token);
+        }
+
+        HttpResponse<String> response = httpClient.send(builder.build(), HttpResponse.BodyHandlers.ofString());
+        JsonNode json = response.body() == null || response.body().isBlank()
+                ? MAPPER.createObjectNode()
+                : MAPPER.readTree(response.body());
+        if (response.statusCode() < 200 || response.statusCode() >= 300) {
+            throw new IOException("NcatBot API 调用失败，HTTP " + response.statusCode() + ": " + json);
+        }
+        if (json.path("ok").isBoolean() && !json.path("ok").asBoolean()) {
+            throw new IOException("NcatBot API 调用失败: " + json.path("error").asText(json.toString()));
+        }
+        return json.has("data") ? json.get("data") : json;
+    }
+
+    public JsonNode sendGroupText(long groupId, String text) throws IOException, InterruptedException {
+        return call("post_group_msg", Map.of("group_id", groupId, "text", text));
+    }
+
+    public JsonNode sendPrivateText(long userId, String text) throws IOException, InterruptedException {
+        return call("post_private_msg", Map.of("user_id", userId, "text", text));
+    }
+
+    public JsonNode deleteMsg(long messageId) throws IOException, InterruptedException {
+        return call("delete_msg", Map.of("message_id", messageId));
+    }
+
+    public JsonNode setGroupBan(long groupId, long userId, long durationSeconds) throws IOException, InterruptedException {
+        return call("set_group_ban", Map.of("group_id", groupId, "user_id", userId, "duration", durationSeconds));
+    }
+
+    public JsonNode setGroupKick(long groupId, long userId, boolean rejectAddRequest) throws IOException, InterruptedException {
+        return call("set_group_kick", Map.of("group_id", groupId, "user_id", userId, "reject_add_request", rejectAddRequest));
+    }
+
+    public JsonNode getLoginInfo() throws IOException, InterruptedException {
+        return call("get_login_info", Collections.emptyMap());
+    }
+
+    private String stripTrailingSlash(String value) {
+        if (value == null || value.isBlank()) {
+            return "http://127.0.0.1:8765";
+        }
+        String result = value;
+        while (result.endsWith("/")) {
+            result = result.substring(0, result.length() - 1);
+        }
+        return result;
+    }
+}

--- a/ncatbot-java-sdk/src/main/java/xyz/ncatbot/java/sdk/NcatBotContext.java
+++ b/ncatbot-java-sdk/src/main/java/xyz/ncatbot/java/sdk/NcatBotContext.java
@@ -1,0 +1,30 @@
+package xyz.ncatbot.java.sdk;
+
+import java.nio.file.Path;
+
+/**
+ * 插件运行上下文，提供 API、插件名和工作目录。
+ */
+public class NcatBotContext {
+    private final BotApi botApi;
+    private final String pluginName;
+    private final Path workDir;
+
+    public NcatBotContext(BotApi botApi, String pluginName, Path workDir) {
+        this.botApi = botApi;
+        this.pluginName = pluginName;
+        this.workDir = workDir;
+    }
+
+    public BotApi getBotApi() {
+        return botApi;
+    }
+
+    public String getPluginName() {
+        return pluginName;
+    }
+
+    public Path getWorkDir() {
+        return workDir;
+    }
+}

--- a/ncatbot-java-sdk/src/main/java/xyz/ncatbot/java/sdk/NcatBotEvent.java
+++ b/ncatbot-java-sdk/src/main/java/xyz/ncatbot/java/sdk/NcatBotEvent.java
@@ -1,0 +1,155 @@
+package xyz.ncatbot.java.sdk;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+/**
+ * NcatBot 事件包装类，保留原始 JSON 并提供常用字段读取方法。
+ */
+public class NcatBotEvent {
+    private final String type;
+    private final String platform;
+    private final JsonNode data;
+    private final JsonNode raw;
+    private final NcatBotContext context;
+
+    public NcatBotEvent(String type, String platform, JsonNode data, JsonNode raw, NcatBotContext context) {
+        this.type = type == null ? "" : type;
+        this.platform = platform == null ? "" : platform;
+        this.data = data;
+        this.raw = raw;
+        this.context = context;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public String getPlatform() {
+        return platform;
+    }
+
+    public JsonNode getData() {
+        return data;
+    }
+
+    public JsonNode getRaw() {
+        return raw;
+    }
+
+    public NcatBotContext getContext() {
+        return context;
+    }
+
+    public BotApi getBotApi() {
+        return context.getBotApi();
+    }
+
+    public String getText() {
+        String direct = firstText("text", "raw_message", "content", "msg");
+        if (!direct.isBlank()) {
+            return direct;
+        }
+        JsonNode message = findField("message");
+        if (message != null && message.isTextual()) {
+            return message.asText();
+        }
+        if (message != null && message.isArray()) {
+            StringBuilder builder = new StringBuilder();
+            for (JsonNode segment : message) {
+                String type = segment.path("type").asText("");
+                if ("text".equals(type)) {
+                    builder.append(segment.path("data").path("text").asText(""));
+                }
+            }
+            return builder.toString();
+        }
+        return "";
+    }
+
+    public Long getGroupId() {
+        return firstLong("group_id", "groupId", "group");
+    }
+
+    public Long getUserId() {
+        return firstLong("user_id", "userId", "sender_id", "senderId", "operator_id", "operatorId");
+    }
+
+    public Long getMessageId() {
+        return firstLong("message_id", "messageId", "msg_id", "msgId");
+    }
+
+    public boolean isGroupMessage() {
+        return getGroupId() != null || type.toLowerCase().contains("group");
+    }
+
+    public boolean isPrivateMessage() {
+        return getGroupId() == null && (getUserId() != null || type.toLowerCase().contains("private"));
+    }
+
+    private String firstText(String... names) {
+        for (String name : names) {
+            JsonNode node = findField(name);
+            if (node != null && !node.isNull()) {
+                if (node.isTextual()) {
+                    return node.asText();
+                }
+                if (node.isValueNode()) {
+                    return node.asText();
+                }
+            }
+        }
+        return "";
+    }
+
+    private Long firstLong(String... names) {
+        for (String name : names) {
+            JsonNode node = findField(name);
+            if (node != null && !node.isNull()) {
+                if (node.canConvertToLong()) {
+                    return node.asLong();
+                }
+                if (node.isTextual()) {
+                    try {
+                        return Long.parseLong(node.asText());
+                    } catch (NumberFormatException ignored) {
+                        // 忽略无法转为数字的字段，继续尝试其他名称。
+                    }
+                }
+            }
+        }
+        return null;
+    }
+
+    private JsonNode findField(String name) {
+        JsonNode node = getField(data, name);
+        if (node != null) {
+            return node;
+        }
+        return getField(raw, name);
+    }
+
+    private JsonNode getField(JsonNode root, String name) {
+        if (root == null || root.isNull()) {
+            return null;
+        }
+        JsonNode direct = root.get(name);
+        if (direct != null) {
+            return direct;
+        }
+        JsonNode eventData = root.get("data");
+        if (eventData != null) {
+            direct = eventData.get(name);
+            if (direct != null) {
+                return direct;
+            }
+        }
+        JsonNode sender = root.get("sender");
+        if (sender != null) {
+            direct = sender.get(name);
+            if (direct != null) {
+                return direct;
+            }
+        }
+        return null;
+    }
+}

--- a/ncatbot-java-sdk/src/main/java/xyz/ncatbot/java/sdk/NcatBotJavaRuntime.java
+++ b/ncatbot-java-sdk/src/main/java/xyz/ncatbot/java/sdk/NcatBotJavaRuntime.java
@@ -1,0 +1,161 @@
+package xyz.ncatbot.java.sdk;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.ServiceLoader;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
+
+/**
+ * Java 插件运行时：加载插件、启动 HTTP 服务、接收 Python 桥接插件转发的事件。
+ */
+public class NcatBotJavaRuntime {
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    public static void run(String[] args) throws Exception {
+        List<NcatBotPlugin> plugins = new ArrayList<>();
+        ServiceLoader.load(NcatBotPlugin.class).forEach(plugins::add);
+        if (plugins.isEmpty()) {
+            throw new IllegalStateException("未通过 ServiceLoader 找到 NcatBotPlugin 实现");
+        }
+        run(plugins, args);
+    }
+
+    public static void run(NcatBotPlugin plugin, String[] args) throws Exception {
+        run(List.of(plugin), args);
+    }
+
+    public static void run(List<NcatBotPlugin> plugins, String[] args) throws Exception {
+        RuntimeOptions options = RuntimeOptions.parse(args);
+        BotApi botApi = new BotApi(options.apiUrl, options.token);
+        NcatBotContext context = new NcatBotContext(botApi, options.pluginName, options.workDir);
+
+        for (NcatBotPlugin plugin : plugins) {
+            plugin.onLoad(context);
+        }
+
+        HttpServer server = HttpServer.create(new InetSocketAddress("127.0.0.1", options.port), 0);
+        server.createContext("/health", exchange -> writeJson(exchange, 200, okJson("ok")));
+        server.createContext("/ncatbot/event", exchange -> handleEvent(exchange, plugins, context));
+        server.setExecutor(Executors.newCachedThreadPool());
+
+        CountDownLatch shutdownLatch = new CountDownLatch(1);
+        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+            for (NcatBotPlugin plugin : plugins) {
+                try {
+                    plugin.onUnload();
+                } catch (Exception e) {
+                    e.printStackTrace();
+                }
+            }
+            server.stop(0);
+            shutdownLatch.countDown();
+        }));
+
+        server.start();
+        System.out.println("NcatBot Java 插件运行中，监听端口 " + options.port);
+        shutdownLatch.await();
+    }
+
+    private static void handleEvent(HttpExchange exchange, List<NcatBotPlugin> plugins, NcatBotContext context) throws IOException {
+        if (!"POST".equalsIgnoreCase(exchange.getRequestMethod())) {
+            writeJson(exchange, 405, errorJson("仅支持 POST"));
+            return;
+        }
+        try (InputStream inputStream = exchange.getRequestBody()) {
+            JsonNode raw = MAPPER.readTree(inputStream);
+            String type = raw.path("type").asText(raw.path("post_type").asText(""));
+            String platform = raw.path("platform").asText("ncatbot");
+            JsonNode data = raw.has("data") ? raw.get("data") : raw;
+            NcatBotEvent event = new NcatBotEvent(type, platform, data, raw, context);
+            for (NcatBotPlugin plugin : plugins) {
+                plugin.onEvent(event);
+            }
+            writeJson(exchange, 200, okJson("event accepted"));
+        } catch (Exception e) {
+            e.printStackTrace();
+            writeJson(exchange, 500, errorJson(e.getMessage() == null ? e.getClass().getName() : e.getMessage()));
+        }
+    }
+
+    private static ObjectNode okJson(String message) {
+        ObjectNode node = MAPPER.createObjectNode();
+        node.put("ok", true);
+        node.put("message", message);
+        return node;
+    }
+
+    private static ObjectNode errorJson(String error) {
+        ObjectNode node = MAPPER.createObjectNode();
+        node.put("ok", false);
+        node.put("error", error);
+        return node;
+    }
+
+    private static void writeJson(HttpExchange exchange, int status, JsonNode json) throws IOException {
+        byte[] bytes = MAPPER.writeValueAsBytes(json);
+        exchange.getResponseHeaders().set("Content-Type", "application/json; charset=utf-8");
+        exchange.sendResponseHeaders(status, bytes.length);
+        try (OutputStream outputStream = exchange.getResponseBody()) {
+            outputStream.write(bytes);
+        }
+    }
+
+    private static class RuntimeOptions {
+        private int port = 0;
+        private String apiUrl = "http://127.0.0.1:8765";
+        private String token = "";
+        private String pluginName = "java-plugin";
+        private Path workDir = Path.of(".").toAbsolutePath().normalize();
+
+        private static RuntimeOptions parse(String[] args) {
+            RuntimeOptions options = new RuntimeOptions();
+            for (int i = 0; i < args.length; i++) {
+                String arg = args[i];
+                String value = null;
+                int eq = arg.indexOf('=');
+                if (eq > 0) {
+                    value = arg.substring(eq + 1);
+                    arg = arg.substring(0, eq);
+                } else if (i + 1 < args.length) {
+                    value = args[++i];
+                }
+
+                if ("--ncatbot-plugin-port".equals(arg)) {
+                    options.port = Integer.parseInt(requireValue(arg, value));
+                } else if ("--ncatbot-api-url".equals(arg)) {
+                    options.apiUrl = requireValue(arg, value);
+                } else if ("--ncatbot-token".equals(arg)) {
+                    options.token = requireValue(arg, value);
+                } else if ("--ncatbot-plugin-name".equals(arg)) {
+                    options.pluginName = requireValue(arg, value);
+                } else if ("--ncatbot-work-dir".equals(arg)) {
+                    options.workDir = Path.of(requireValue(arg, value)).toAbsolutePath().normalize();
+                }
+            }
+            if (options.port <= 0) {
+                throw new IllegalArgumentException("缺少启动参数 --ncatbot-plugin-port");
+            }
+            return options;
+        }
+
+        private static String requireValue(String name, String value) {
+            if (value == null || value.isBlank()) {
+                throw new IllegalArgumentException("参数 " + name + " 需要值");
+            }
+            return value;
+        }
+    }
+}

--- a/ncatbot-java-sdk/src/main/java/xyz/ncatbot/java/sdk/NcatBotPlugin.java
+++ b/ncatbot-java-sdk/src/main/java/xyz/ncatbot/java/sdk/NcatBotPlugin.java
@@ -1,0 +1,23 @@
+package xyz.ncatbot.java.sdk;
+
+/**
+ * NcatBot Java 插件入口接口。
+ */
+public interface NcatBotPlugin {
+    /**
+     * 插件加载时调用。
+     */
+    default void onLoad(NcatBotContext context) throws Exception {
+    }
+
+    /**
+     * 收到 NcatBot 事件时调用。
+     */
+    void onEvent(NcatBotEvent event) throws Exception;
+
+    /**
+     * 插件卸载或进程退出时调用。
+     */
+    default void onUnload() throws Exception {
+    }
+}

--- a/ncatbot-java-sdk/src/main/resources/META-INF/services/xyz.ncatbot.java.sdk.NcatBotPlugin
+++ b/ncatbot-java-sdk/src/main/resources/META-INF/services/xyz.ncatbot.java.sdk.NcatBotPlugin
@@ -1,0 +1,1 @@
+xyz.ncatbot.java.example.HelloPlugin

--- a/ncatbot/plugin/builtin/java_bridge/main.py
+++ b/ncatbot/plugin/builtin/java_bridge/main.py
@@ -1,0 +1,191 @@
+import asyncio
+import json
+import os
+import secrets
+import socket
+import subprocess
+import sys
+from pathlib import Path
+from urllib import request
+
+from ncatbot.core import registrar
+from ncatbot.plugin import BasePlugin
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+class NcatBotJavaBridgePlugin(BasePlugin):
+    name = "ncatbot_java_bridge"
+    version = "1.0.0"
+    author = "NcatBot Java"
+    description = "加载并桥接 plugins 目录中的 NcatBot Java Jar 插件"
+
+    def _init_(self):
+        self._processes = []
+        self._token = secrets.token_urlsafe(24)
+        self._api_port = _free_port()
+        self._api_server = None
+        self._api_runner_task = None
+        self._event_targets = []
+
+    async def on_load(self):
+        await self._start_api_server()
+        await self._start_java_jars()
+
+    async def on_close(self):
+        for process in self._processes:
+            if process.poll() is None:
+                process.terminate()
+        for process in self._processes:
+            try:
+                process.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                process.kill()
+        if self._api_server is not None:
+            self._api_server.close()
+            await self._api_server.wait_closed()
+        if self._api_runner_task is not None:
+            self._api_runner_task.cancel()
+
+    async def _start_api_server(self):
+        self._api_server = await asyncio.start_server(
+            self._handle_api_connection,
+            host="127.0.0.1",
+            port=self._api_port,
+        )
+        self._api_runner_task = asyncio.create_task(self._api_server.serve_forever())
+        self.logger.info("Java Bridge API 服务已启动: http://127.0.0.1:%s", self._api_port)
+
+    async def _start_java_jars(self):
+        plugins_dir = self._manifest.plugin_path.parent if self._manifest else Path("plugins")
+        jar_files = [p for p in plugins_dir.iterdir() if p.is_file() and p.suffix.lower() == ".jar"]
+        if not jar_files:
+            self.logger.info("未发现 Java Jar 插件，请将 jar 放入 plugins 目录")
+            return
+
+        for jar_file in jar_files:
+            event_port = _free_port()
+            work_dir = self.workspace / jar_file.stem
+            work_dir.mkdir(parents=True, exist_ok=True)
+            command = [
+                "java",
+                "-jar",
+                str(jar_file),
+                "--ncatbot-plugin-port",
+                str(event_port),
+                "--ncatbot-api-url",
+                f"http://127.0.0.1:{self._api_port}",
+                "--ncatbot-token",
+                self._token,
+                "--ncatbot-plugin-name",
+                jar_file.stem,
+                "--ncatbot-work-dir",
+                str(work_dir),
+            ]
+            process = subprocess.Popen(command, cwd=str(plugins_dir))
+            self._processes.append(process)
+            self._event_targets.append((jar_file.stem, event_port))
+            self.logger.info("已启动 Java 插件 %s，事件端口 %s", jar_file.name, event_port)
+
+    async def _handle_api_connection(self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter):
+        try:
+            header_bytes = await reader.readuntil(b"\r\n\r\n")
+            headers_text = header_bytes.decode("iso-8859-1")
+            lines = headers_text.split("\r\n")
+            request_line = lines[0]
+            method, path, _ = request_line.split(" ", 2)
+            headers = {}
+            for line in lines[1:]:
+                if ":" in line:
+                    key, value = line.split(":", 1)
+                    headers[key.strip().lower()] = value.strip()
+            length = int(headers.get("content-length", "0"))
+            body = await reader.readexactly(length) if length > 0 else b"{}"
+
+            auth = headers.get("authorization", "")
+            token = headers.get("x-ncatbot-token", "")
+            if auth != f"Bearer {self._token}" and token != self._token:
+                await self._write_response(writer, 401, {"ok": False, "error": "unauthorized"})
+                return
+            if method.upper() != "POST" or path != "/api/call":
+                await self._write_response(writer, 404, {"ok": False, "error": "not found"})
+                return
+
+            payload = json.loads(body.decode("utf-8"))
+            action = payload.get("action")
+            params = payload.get("params") or {}
+            result = await self._call_bot_api(action, params)
+            await self._write_response(writer, 200, {"ok": True, "data": result})
+        except Exception as exc:
+            await self._write_response(writer, 500, {"ok": False, "error": str(exc)})
+        finally:
+            writer.close()
+            await writer.wait_closed()
+
+    async def _write_response(self, writer: asyncio.StreamWriter, status: int, payload: dict):
+        reason = "OK" if status == 200 else "ERROR"
+        body = json.dumps(payload, ensure_ascii=False, default=str).encode("utf-8")
+        writer.write(
+            f"HTTP/1.1 {status} {reason}\r\nContent-Type: application/json; charset=utf-8\r\nContent-Length: {len(body)}\r\nConnection: close\r\n\r\n".encode("utf-8")
+            + body
+        )
+        await writer.drain()
+
+    async def _call_bot_api(self, action: str, params: dict):
+        if not action:
+            raise ValueError("缺少 action")
+        qq = self.api.qq
+        if action in {"send_group_msg", "send_private_msg", "delete_msg"}:
+            target = qq.messaging
+        elif action.startswith("set_") or action in {"send_group_notice", "delete_group_notice"}:
+            target = qq.manage
+        elif action.startswith("get_") or action in {"ocr_image", "fetch_emoji_like"}:
+            target = qq.query
+        elif action in {"upload_group_file", "delete_group_file", "download_file"}:
+            target = qq.file
+        else:
+            target = qq
+        method = getattr(target, action)
+        return await method(**params)
+
+    async def _dispatch_to_java(self, event):
+        if not self._event_targets:
+            return
+        payload = json.dumps(_event_to_dict(event), ensure_ascii=False, default=str).encode("utf-8")
+        for name, port in list(self._event_targets):
+            await asyncio.to_thread(self._post_event, name, port, payload)
+
+    def _post_event(self, name: str, port: int, payload: bytes):
+        req = request.Request(
+            f"http://127.0.0.1:{port}/ncatbot/event",
+            data=payload,
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        try:
+            with request.urlopen(req, timeout=10) as resp:
+                resp.read()
+        except Exception as exc:
+            self.logger.warning("转发事件到 Java 插件 %s 失败: %s", name, exc)
+
+
+@registrar.on("message")
+@registrar.on("notice")
+@registrar.on("request")
+@registrar.on("meta_event")
+async def _forward_all_events(self: NcatBotJavaBridgePlugin, event):
+    await self._dispatch_to_java(event)
+
+
+def _event_to_dict(event):
+    data = getattr(event, "data", None)
+    raw_data = data.model_dump(mode="json") if hasattr(data, "model_dump") else getattr(data, "__dict__", data)
+    return {
+        "type": getattr(event, "type", ""),
+        "platform": getattr(event, "platform", "qq"),
+        "data": raw_data,
+    }

--- a/ncatbot/plugin/builtin/java_bridge/manifest.toml
+++ b/ncatbot/plugin/builtin/java_bridge/manifest.toml
@@ -1,0 +1,6 @@
+name = "ncatbot_java_bridge"
+version = "1.0.0"
+main = "main"
+entry_class = "NcatBotJavaBridgePlugin"
+author = "NcatBot Java"
+description = "加载并桥接 plugins 目录中的 NcatBot Java Jar 插件"


### PR DESCRIPTION
- ncatbot-java-sdk/: Java SDK project (Maven, JDK 17, Jackson)
  - BotApi / NcatBotEvent / NcatBotPlugin / NcatBotJavaRuntime
  - ServiceLoader plugin discovery
  - Example: HelloPlugin
- ncatbot/plugin/builtin/java_bridge/: Python bridge plugin
  - Auto-loads JAR files from plugins directory
  - Forwards events to Java plugins via HTTP
  - Proxies Bot API calls back to NcatBot