### PR TITLE
fix(types): 修复QQ群根目录文件获取时的类型校验失败问题

### DIFF
--- a/ncatbot/types/napcat/file.py
+++ b/ncatbot/types/napcat/file.py
@@ -35,7 +35,7 @@ class GroupFileInfo(NapCatModel):
     dead_time: Optional[int] = None
     modify_time: Optional[int] = None
     download_times: Optional[int] = None
-    uploader: str = ""
+    uploader: str | int = ""
     uploader_name: Optional[str] = None
 
 
@@ -50,7 +50,7 @@ class GroupFolderInfo(NapCatModel):
     folder_id: str = ""
     folder_name: Optional[str] = None
     create_time: Optional[int] = None
-    creator: str = ""
+    creator: str | int = ""
     creator_name: Optional[str] = None
     total_file_count: Optional[int] = None
 


### PR DESCRIPTION
## 问题

参考 [napcat](https://github.com/NapNeko/NapCatQQ/blob/738e272d2c46bff6882751b26a742f891d95152b/packages/napcat-onebot/types/data.ts)  中的类型定义，uploader 和 creator 均为 number。NapCatModel中虽然对id字段做了统一的类型转换，但未能覆盖这两个参数，因此调用相关方法会出现类型校验失败问题

## 修改

- 将 GroupFileInfo.uploader 的类型由 str 调整为 str | int
- 将 GroupFolderInfo.creator 的类型由 str 调整为 str | int
- 保留原有字符串类型兼容性，避免破坏性更新

另外参照napcat（4.18.9）的类型定义 大致浏览了下ncatbot/types/napcat下的其他model，应该没有类似的问题了

Fixes #48