### PR TITLE
fix(napcat): 修复 get_forward_msg 转发消息 ID 精度丢失

### DIFF
--- a/ncatbot/adapter/napcat/api/query.py
+++ b/ncatbot/adapter/napcat/api/query.py
@@ -85,7 +85,7 @@ class QueryAPIMixin:
 
     async def get_forward_msg(self, message_id: Union[str, int]) -> ForwardMessageData:
         data = (
-            await self._call_data("get_forward_msg", {"message_id": int(message_id)})
+            await self._call_data("get_forward_msg", {"id": str(message_id)})
             or {}
         )
         return ForwardMessageData(**data)

--- a/tests/unit/adapter/test_napcat_query_api.py
+++ b/tests/unit/adapter/test_napcat_query_api.py
@@ -1,0 +1,43 @@
+"""NapCat 查询 API 单元测试。
+
+规范:
+  NQ-01: get_forward_msg 使用 OneBot 标准 id 参数
+  NQ-02: get_forward_msg 保留超过 JavaScript 安全整数范围的完整 ID
+"""
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from ncatbot.adapter.napcat.api.query import QueryAPIMixin
+
+
+class _FakeQueryMixin(QueryAPIMixin):
+    """为测试提供底层 API 调用方法。"""
+
+    def __init__(self):
+        self._call_data = AsyncMock(return_value={"messages": []})
+
+
+class TestNapCatQueryAPI:
+    """NapCat 查询 API 参数转换测试。"""
+
+    @pytest.mark.parametrize(
+        "message_id",
+        [
+            "7672696335120716277",
+            7672696335120716277,
+        ],
+    )
+    @pytest.mark.asyncio
+    async def test_nq01_get_forward_msg_preserves_long_id(self, message_id):
+        """NQ-01/02: 转发消息长 ID 始终通过字符串 id 原样传递。"""
+        api = _FakeQueryMixin()
+
+        result = await api.get_forward_msg(message_id)
+
+        api._call_data.assert_awaited_once_with(
+            "get_forward_msg",
+            {"id": "7672696335120716277"},
+        )
+        assert result.messages == []


### PR DESCRIPTION
## 问题说明

`QueryAPIMixin.get_forward_msg()` 当前会将传入的转发消息 ID 强制转换为 `int`，并通过 `message_id` 参数发送给 NapCat：

```python
{"message_id": int(message_id)}
```

但 OneBot 11 规范中，`get_forward_msg` 使用的参数是字符串类型的 `id`。NapCat 当前也将 `message_id` 和 `id` 兼容参数定义为字符串。

## 问题原因

NapCat 产生的消息 ID 可能是超过 JavaScript 安全整数范围的 64 位数字字符串，例如：

```text
7672696335120716277
```

NCatBot 将其转换为 Python `int` 后，JSON 会把它作为数字发送。NapCat 运行于 Node.js，解析该数字时可能发生精度丢失。

可以使用以下 JavaScript 代码复现：

```javascript
const id = "7672696335120716277";

console.log(String(Number(id)));
console.log(String(Number(id)) === id);
```

第二行结果为：

```text
false
```

当消息 ID 精度丢失后，NapCat 无法在消息映射中找到对应消息，最终可能返回：

```text
API 调用失败 [1200]
action=get_forward_msg
消息已过期或者为内层消息，无法获取转发消息
```

## 复现方式

接收到包含长 ID 的合并转发消息：

```text
[CQ:forward,id=7672696335120716277]
```

然后调用：

```python
await api.get_forward_msg("7672696335120716277")
```

修改前实际发送的参数类似：

```json
{
  "action": "get_forward_msg",
  "params": {
    "message_id": 7672696335120716277
  }
}
```

此时 ID 会以 JSON 数字形式进入 Node.js，存在精度丢失风险。

## 修改内容

将调用参数修改为 OneBot 11 规范中的 `id`，并始终以字符串传递：

```python
{"id": str(message_id)}
```

修改后发送的参数为：

```json
{
  "action": "get_forward_msg",
  "params": {
    "id": "7672696335120716277"
  }
}
```

公开方法仍然保留原有的 `Union[str, int]` 参数类型，因此不会破坏现有调用方式。

## 测试

增加回归测试，覆盖字符串和整数形式的 19 位消息 ID，并确认两种输入最终都会完整转换为：

```python
{"id": "7672696335120716277"}
```

## 修改范围

本次 PR 只修复 `get_forward_msg` 的参数类型与参数名称，不修改其他 API 的 ID 处理逻辑。

真正已经过期、已离开消息缓存，或者 NapCat 当前不支持读取的内层嵌套转发消息，仍可能返回相同错误，不属于本次修复范围。

## 参考

- OneBot 11 `get_forward_msg` 接口规范：https://github.com/botuniverse/onebot-11/blob/master/api/public.md#get_forward_msg-获取合并转发消息
- NapCat `GetForwardMsg` 实现：https://github.com/NapNeko/NapCatQQ/blob/main/packages/napcat-onebot/action/go-cqhttp/GetForwardMsg.ts
