### PR TITLE
Feat/为event_mixin添加wait_private_event和wait_group_event支持 (issue #24)

### DIFF
--- a/ncatbot/plugin/mixin/event_mixin.py
+++ b/ncatbot/plugin/mixin/event_mixin.py
@@ -11,7 +11,7 @@ session 绑定、取消词检测、超时处理和自动回复等常用模式。
 
 import asyncio
 
-#新增cast引入
+# 新增cast引入,Type引入,TypeVar引入
 from typing import (
     Callable,
     Dict,
@@ -20,9 +20,10 @@ from typing import (
     Sequence,
     Union,
     TYPE_CHECKING,
-    cast
+    cast,
+    TypeVar,
+    Type,
 )
-
 from ncatbot.utils import get_log
 
 from .session_types import SessionCancelled, SessionResult
@@ -31,10 +32,15 @@ if TYPE_CHECKING:
     from ncatbot.core import AsyncEventDispatcher, Event, EventStream, P
     from ncatbot.types.qq import EventType
 
-#新增事件类型引入
-from ncatbot.event.qq.message import GroupMessageEvent,PrivateMessageEvent
+# 新增事件类型引入,引入事件工厂
+from ncatbot.event.qq.message import GroupMessageEvent, PrivateMessageEvent
+from ncatbot.event.qq.factory import create_qq_entity
+from ncatbot.api.qq.client import IQQAPIClient
+
 LOG = get_log("EventMixin")
 
+# 定义泛型 TypeVar
+EventT = TypeVar("EventT")
 
 
 class EventMixin:
@@ -92,11 +98,52 @@ class EventMixin:
         """
         return await self._dispatcher.wait_event(predicate, timeout)
 
-    #新增：内建的wait_group_message类型
+    # 新增：将类型过滤、事件实体转换和 predicate 调用抽取为内部通用包装方法
+    async def _wait_entity(
+        self,
+        event_type: Type[EventT],
+        predicate: Optional[Callable[[EventT], bool]] = None,
+        timeout: Optional[float] = None,
+    ) -> EventT:
+        """
+        内部通用等待实体方法：
+        进行过滤类型与数据转换，运行 predicate 断言
+        支持精确泛型推导返回
+        """
+        matched_entity: Optional[EventT] = None
+
+        def _check(raw_event: Event) -> bool:
+            nonlocal matched_entity
+
+            # 通过现有事件工厂将 Event.data 转换成真实事件实体
+            api_client = cast(IQQAPIClient, getattr(self, "api", self))
+            entity = create_qq_entity(raw_event.data, api_client)
+
+            # isinstance 判断
+            if entity is None or not isinstance(entity, event_type):
+                return False
+            if predicate is not None:
+                return predicate(entity)
+
+            matched_entity = entity
+            return True
+
+        # 调用底层 wait_event
+        raw_event: Event = await self.wait_event(_check, timeout=timeout)
+
+        # 返回符合条件的实例
+        if matched_entity is not None:
+            return matched_entity
+
+        api_client = api_client = cast(IQQAPIClient, getattr(self, "api", self))
+
+        return cast(EventT, create_qq_entity(raw_event.data, api_client))
+
+    # 新增：内建的wait_group_message类型
     async def wait_group_message_event(
-            self,
-            predicate: Optional[Callable[[GroupMessageEvent],bool]] = None,
-            timeout: Optional[float] = None,
+        self,
+        predicate: Optional[Callable[[GroupMessageEvent], bool]] = None,
+        timeout: Optional[float] = None,
     ) -> GroupMessageEvent:
         """等待下一个满足条件的群聊消息事件,封装wait_event
 
@@ -106,32 +153,18 @@ class EventMixin:
 
         Returns:
             匹配的 GroupMessageEvent
-
-        Raises:
-            asyncio.TimeoutError: 超时未匹配到事件
-            注：这个抛出来自于底层的wait_event
         """
 
-        #包装群组的过滤函数
-        def wrapper_predicate(e: "Event") -> bool:
-            if not isinstance(e, GroupMessageEvent):
-                return False
+        # 统一调用 _wait_entity
+        return await self._wait_entity(
+            GroupMessageEvent, predicate=predicate, timeout=timeout
+        )
 
-            #要是用户传入自己的包装器就返回它的判断就好啦
-            if predicate is not None:
-                return predicate(e)
-            
-            return True
-
-        event = await self.wait_event(wrapper_predicate, timeout)
-        #用cast强制转换，这样ide就可以自己推断类型
-        return cast(GroupMessageEvent, event)
-        
-    #新增：内建的wait_private_message类型
+    # 新增：内建的wait_private_message类型
     async def wait_private_message_event(
-            self,
-            predicate: Optional[Callable[[PrivateMessageEvent], bool]] = None,
-            timeout: Optional[float] = None,
+        self,
+        predicate: Optional[Callable[[PrivateMessageEvent], bool]] = None,
+        timeout: Optional[float] = None,
     ) -> PrivateMessageEvent:
         """等待下一个满足条件的私聊消息事件,封装wait_event
 
@@ -141,29 +174,12 @@ class EventMixin:
 
         Returns:
             匹配的 PrivateMessageEvent
-
-        Raises:      
-            asyncio.TimeoutError: 超时未匹配到事件
-            注：这个抛出来自于底层的wait_event
         """
-        #手法包装私聊过滤函数
-        def wrapper_predicate(e: "Event") -> bool:
-            if not isinstance(e, PrivateMessageEvent):
-                return False
 
-            if predicate is not None:
-                return predicate(e)
-
-            return True
-
-        
-        event = await self.wait_event(wrapper_predicate, timeout)
-
-        #用cast强制转换，这样ide就可以自己推断类型
-        return cast(PrivateMessageEvent, event)
-
-
-
+        # 统一调用 _wait_entity
+        return await self._wait_entity(
+            PrivateMessageEvent, predicate=predicate, timeout=timeout
+        )
 
     # ------------------------------------------------------------------
     # Session 便利方法

--- a/ncatbot/plugin/mixin/event_mixin.py
+++ b/ncatbot/plugin/mixin/event_mixin.py
@@ -10,6 +10,8 @@ session 绑定、取消词检测、超时处理和自动回复等常用模式。
 """
 
 import asyncio
+
+#新增cast引入
 from typing import (
     Callable,
     Dict,
@@ -18,6 +20,7 @@ from typing import (
     Sequence,
     Union,
     TYPE_CHECKING,
+    cast
 )
 
 from ncatbot.utils import get_log
@@ -28,7 +31,10 @@ if TYPE_CHECKING:
     from ncatbot.core import AsyncEventDispatcher, Event, EventStream, P
     from ncatbot.types.qq import EventType
 
+#新增事件类型引入
+from ncatbot.event.qq.message import GroupMessageEvent,PrivateMessageEvent
 LOG = get_log("EventMixin")
+
 
 
 class EventMixin:
@@ -85,6 +91,79 @@ class EventMixin:
             asyncio.TimeoutError: 超时未匹配到事件
         """
         return await self._dispatcher.wait_event(predicate, timeout)
+
+    #新增：内建的wait_group_message类型
+    async def wait_group_message_event(
+            self,
+            predicate: Optional[Callable[[GroupMessageEvent],bool]] = None,
+            timeout: Optional[float] = None,
+    ) -> GroupMessageEvent:
+        """等待下一个满足条件的群聊消息事件,封装wait_event
+
+        Args:
+            predicate: 针对群聊消息的过滤函数，None 表示接受任意事件
+            timeout: 超时秒数，None 表示无限等待
+
+        Returns:
+            匹配的 GroupMessageEvent
+
+        Raises:
+            asyncio.TimeoutError: 超时未匹配到事件
+            注：这个抛出来自于底层的wait_event
+        """
+
+        #包装群组的过滤函数
+        def wrapper_predicate(e: "Event") -> bool:
+            if not isinstance(e, GroupMessageEvent):
+                return False
+
+            #要是用户传入自己的包装器就返回它的判断就好啦
+            if predicate is not None:
+                return predicate(e)
+            
+            return True
+
+        event = await self.wait_event(wrapper_predicate, timeout)
+        #用cast强制转换，这样ide就可以自己推断类型
+        return cast(GroupMessageEvent, event)
+        
+    #新增：内建的wait_private_message类型
+    async def wait_private_message_event(
+            self,
+            predicate: Optional[Callable[[PrivateMessageEvent], bool]] = None,
+            timeout: Optional[float] = None,
+    ) -> PrivateMessageEvent:
+        """等待下一个满足条件的私聊消息事件,封装wait_event
+
+        Args:
+            predicate: 针对私聊消息的过滤函数，None 表示接受任意事件
+            timeout: 超时秒数，None 表示无限等待
+
+        Returns:
+            匹配的 PrivateMessageEvent
+
+        Raises:      
+            asyncio.TimeoutError: 超时未匹配到事件
+            注：这个抛出来自于底层的wait_event
+        """
+        #手法包装私聊过滤函数
+        def wrapper_predicate(e: "Event") -> bool:
+            if not isinstance(e, PrivateMessageEvent):
+                return False
+
+            if predicate is not None:
+                return predicate(e)
+
+            return True
+
+        
+        event = await self.wait_event(wrapper_predicate, timeout)
+
+        #用cast强制转换，这样ide就可以自己推断类型
+        return cast(PrivateMessageEvent, event)
+
+
+
 
     # ------------------------------------------------------------------
     # Session 便利方法


### PR DESCRIPTION
修改说明：
为EventMixin 支持内置的 wait_xxx_event 模式以提供便捷类型支持 （issue #24）
- 添加了wait_private_message_event 和 wait_group_message_event 函数，它包装了wait_event函数，并提供了对应的包装的内置过滤函数

关联Issue：
issue #24 

测试情况：
本地运行的 event_mixin 相关单元测试已通过
<details>
<summary>点击展开 pytest 运行日志</summary>
(ncatbot5) [Sulfur@archlinux NcatBot]$ pytest tests/unit/**/test_*event_mixin*.py
=========================================================================================================== test session starts ============================================================================================================
platform linux -- Python 3.14.7, pytest-9.1.1, pluggy-1.6.0
rootdir: /home/Sulfur/Desktop/ncatbotWork/NcatBot
configfile: pyproject.toml
plugins: metadata-3.1.1, cov-7.1.0, html-4.2.0, asyncio-1.4.0, anyio-4.14.2
asyncio: mode=Mode.AUTO, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 5 items                                                                                                                                                                                                                          

tests/unit/plugin/test_event_mixin.py .....                                                                                                                                                                                          [100%]

============================================================================================================ 5 passed in 0.09s =============================================================================================================

第一次提交代码，如果有不妥的地方请告诉我谢谢喵